### PR TITLE
Make voloverlap ~2.5x faster

### DIFF
--- a/R/voloverlap.R
+++ b/R/voloverlap.R
@@ -223,6 +223,7 @@ if(plot){
     plotrange <- apply(rbind(tcsres1[,c('x','y','z')],tcsres2[,c('x','y','z')]),2,range)
 
     if(length(fill)<3)
+      fill <- c(rep(fill,2)[1:2], 'darkgrey')
 
     if(dim(Voverlap)[1]>3){
       vol(Voverlap, col=col[3], new=new, fill=TRUE,

--- a/R/voloverlap.R
+++ b/R/voloverlap.R
@@ -104,25 +104,25 @@ vol2 <- convhulln(dat2, 'FA')$vol
 #EXACT SOLUTION BEGIN#
 ######################
 if(!montecarlo){
-rat1 <- d2q(cbind(0, cbind(1, as.matrix(dat1))))
-rat2 <- d2q(cbind(0, cbind(1, as.matrix(dat2))))
+rat1 <- d2q(cbind(0, 1, as.matrix(dat1)))
+rat2 <- d2q(cbind(0, 1, as.matrix(dat2)))
 Hvert1 <- scdd(rat1, representation = "V")$output
 Hvert2 <- scdd(rat2, representation = "V")$output
 Hinter <- rbind(Hvert1, Hvert2)
 Vinter <- scdd(Hinter, representation = "H")$output
 
 Voverlap <- data.frame(q2d(Vinter[ , - c(1, 2)]))
-names(Voverlap) = c('x','y','z')
+colnames(Voverlap) <- c('x','y','z')
 
-if(dim(Voverlap)[1]>3){
+if(nrow(Voverlap)>3){
   overlapVol <- convhulln(Voverlap, 'FA')$vol
   }else{
     overlapVol <- 0
     }
 
-vsmallest <- overlapVol/min(c(vol1,vol2))
+vsmallest <- overlapVol/min(vol1,vol2)
 
-vboth <- overlapVol/(sum(c(vol1,vol2))-overlapVol)
+vboth <- overlapVol/(sum(vol1,vol2)-overlapVol)
 
 res <- data.frame(vol1, vol2, overlapvol = overlapVol, vsmallest, vboth)
 }
@@ -244,5 +244,5 @@ if(plot){
 ##########    
 }
 
-res
+return(res)
 }

--- a/R/voloverlap.R
+++ b/R/voloverlap.R
@@ -106,10 +106,8 @@ vol2 <- convhulln(dat2, 'FA')$vol
 if(!montecarlo){
 rat1 <- d2q(cbind(0, cbind(1, as.matrix(dat1))))
 rat2 <- d2q(cbind(0, cbind(1, as.matrix(dat2))))
-vert1 <- redundant(rat1, representation = "V")$output
-vert2 <- redundant(rat2, representation = "V")$output
-Hvert1 <- scdd(vert1, representation = "V")$output
-Hvert2 <- scdd(vert2, representation = "V")$output
+Hvert1 <- scdd(rat1, representation = "V")$output
+Hvert2 <- scdd(rat2, representation = "V")$output
 Hinter <- rbind(Hvert1, Hvert2)
 Vinter <- scdd(Hinter, representation = "H")$output
 

--- a/R/voloverlap.R
+++ b/R/voloverlap.R
@@ -104,27 +104,27 @@ vol2 <- convhulln(dat2, 'FA')$vol
 #EXACT SOLUTION BEGIN#
 ######################
 if(!montecarlo){
-rat1 <- d2q(cbind(0, 1, as.matrix(dat1)))
-rat2 <- d2q(cbind(0, 1, as.matrix(dat2)))
-Hvert1 <- scdd(rat1, representation = "V")$output
-Hvert2 <- scdd(rat2, representation = "V")$output
-Hinter <- rbind(Hvert1, Hvert2)
-Vinter <- scdd(Hinter, representation = "H")$output
+  rat1 <- d2q(cbind(0, 1, as.matrix(dat1)))
+  rat2 <- d2q(cbind(0, 1, as.matrix(dat2)))
+  Hvert1 <- scdd(rat1, representation = "V")$output
+  Hvert2 <- scdd(rat2, representation = "V")$output
+  Hinter <- rbind(Hvert1, Hvert2)
+  Vinter <- scdd(Hinter, representation = "H")$output
 
-Voverlap <- data.frame(q2d(Vinter[ , - c(1, 2)]))
-colnames(Voverlap) <- c('x','y','z')
+  Voverlap <- data.frame(q2d(Vinter[ , - c(1, 2)]))
+  colnames(Voverlap) <- c('x','y','z')
 
-if(nrow(Voverlap)>3){
-  overlapVol <- convhulln(Voverlap, 'FA')$vol
+  if(nrow(Voverlap)>3){
+    overlapVol <- convhulln(Voverlap, 'FA')$vol
   }else{
     overlapVol <- 0
-    }
+  }
 
-vsmallest <- overlapVol/min(vol1,vol2)
+  vsmallest <- overlapVol/min(vol1,vol2)
 
-vboth <- overlapVol/(sum(vol1,vol2)-overlapVol)
+  vboth <- overlapVol/(sum(vol1,vol2)-overlapVol)
 
-res <- data.frame(vol1, vol2, overlapvol = overlapVol, vsmallest, vboth)
+  res <- data.frame(vol1, vol2, overlapvol = overlapVol, vsmallest, vboth)
 }
 
 ####################
@@ -136,40 +136,40 @@ res <- data.frame(vol1, vol2, overlapvol = overlapVol, vsmallest, vboth)
 ###################
 
 if(montecarlo){
-# sample random points
-pmin <- apply(rbind(dat1,dat2),2,min)
-pmax <- apply(rbind(dat1,dat2),2,max)
-
-samples <- apply(rbind(pmin,pmax), 2, function(x) runif(nsamp,x[1],x[2]))
-
-sindex <- 1:dim(samples)[1]
-
-newvol1 <- sapply(sindex, function(x) convhulln(rbind(dat1,samples[x,]),'FA')$vol)
-newvol2 <- sapply(sindex, function(x) convhulln(rbind(dat2,samples[x,]),'FA')$vol)
-
-# points that are within each volume
-
-invol1 <- sapply(newvol1, function(x) isTRUE(x<=vol1))
-invol2 <- sapply(newvol2, function(x) isTRUE(x<=vol2))
-
-# how many points are in each category
-
-s_in1 <- length(which(invol1))
-s_in2 <- length(which(invol2))
-
-s_inboth <- length(which(invol1 & invol2))
-
-s_ineither <- length(which(invol1 | invol2))
-
-# points in both relative points in smallest
-
-psmallest <- s_inboth / c(s_in1,s_in2)[which.min(c(vol1,vol2))]
-
-# points in both relative to total points in both
-
-pboth <- s_inboth / s_ineither
-
-res <- data.frame(vol1, vol2, s_in1,s_in2,s_inboth,s_ineither,psmallest,pboth)
+  # sample random points
+  pmin <- apply(rbind(dat1,dat2),2,min)
+  pmax <- apply(rbind(dat1,dat2),2,max)
+  
+  samples <- apply(rbind(pmin,pmax), 2, function(x) runif(nsamp,x[1],x[2]))
+  
+  sindex <- 1:dim(samples)[1]
+  
+  newvol1 <- sapply(sindex, function(x) convhulln(rbind(dat1,samples[x,]),'FA')$vol)
+  newvol2 <- sapply(sindex, function(x) convhulln(rbind(dat2,samples[x,]),'FA')$vol)
+  
+  # points that are within each volume
+  
+  invol1 <- sapply(newvol1, function(x) isTRUE(x<=vol1))
+  invol2 <- sapply(newvol2, function(x) isTRUE(x<=vol2))
+  
+  # how many points are in each category
+  
+  s_in1 <- length(which(invol1))
+  s_in2 <- length(which(invol2))
+  
+  s_inboth <- length(which(invol1 & invol2))
+  
+  s_ineither <- length(which(invol1 | invol2))
+  
+  # points in both relative points in smallest
+  
+  psmallest <- s_inboth / c(s_in1,s_in2)[which.min(c(vol1,vol2))]
+  
+  # points in both relative to total points in both
+  
+  pboth <- s_inboth / s_ineither
+  
+  res <- data.frame(vol1, vol2, s_in1,s_in2,s_inboth,s_ineither,psmallest,pboth)
 }
 
 #################
@@ -180,63 +180,63 @@ res <- data.frame(vol1, vol2, s_in1,s_in2,s_inboth,s_ineither,psmallest,pboth)
 #PLOT BEGIN#
 ############
 if(plot){
-    if(length(col)<3)
-      col <- c(rep(col,2)[1:2], 'darkgrey')
+  if(length(col)<3)
+    col <- c(rep(col,2)[1:2], 'darkgrey')
       
       
-	if(interactive){
-	    # check if rgl is installed and loaded
-        if (!requireNamespace("rgl", quietly = TRUE))
-          stop(dQuote('rgl'),' package needed for interactive plots. Please install it, or use interactive=FALSE.',
-            call. = FALSE)  
+  if(interactive){
+  # check if rgl is installed and loaded
+    if (!requireNamespace("rgl", quietly = TRUE))
+      stop(dQuote('rgl'),' package needed for interactive plots. Please install it, or use interactive=FALSE.',
+           call. = FALSE)  
 
-	  if(!isNamespaceLoaded("rgl"))
-	    requireNamespace("rgl")
+    if(!isNamespaceLoaded("rgl"))
+       requireNamespace("rgl")
 	    
-	  if(new)
-        rgl::open3d(FOV=1, mouseMode=c('zAxis','xAxis','zoom'))
+    if(new)
+      rgl::open3d(FOV=1, mouseMode=c('zAxis','xAxis','zoom'))
 
-      tcsvol(tcsres1, col=col[1], fill=F)
-      tcsvol(tcsres2, col=col[2], fill=F)
+    tcsvol(tcsres1, col=col[1], fill=F)
+    tcsvol(tcsres2, col=col[2], fill=F)
       
-      if(!montecarlo){
-        if(dim(Voverlap)[1]>3){
-        	  attr(Voverlap, 'clrsp') <- "tcs"
-          tcsvol(Voverlap, col=col[3])
-          }
-        }
-      
-      if(montecarlo){
-        rgl::spheres3d(samples[which(invol1 & !invol2),], type='s', 
-          lit=F, radius=psize, col=col[1])
-        rgl::spheres3d(samples[which(invol2 & !invol1),], type='s', 
-          lit=F, radius=psize, col=col[2])  
-
-        if(s_inboth > 0){  
-          rgl::spheres3d(samples[which(invol1 & invol2),], type='s', 
-          lit=F, radius=psize, col=col[3])
-        }
+    if(!montecarlo){
+      if(dim(Voverlap)[1]>3){
+        attr(Voverlap, 'clrsp') <- "tcs"
+        tcsvol(Voverlap, col=col[3])
       }
-	}
+    }
+      
+    if(montecarlo){
+      rgl::spheres3d(samples[which(invol1 & !invol2),], type='s', 
+                     lit=F, radius=psize, col=col[1])
+      rgl::spheres3d(samples[which(invol2 & !invol1),], type='s',
+                     lit=F, radius=psize, col=col[2])  
+
+      if(s_inboth > 0){  
+        rgl::spheres3d(samples[which(invol1 & invol2),], type='s', 
+                       lit=F, radius=psize, col=col[3])
+      }
+    }
+  }
 	
-	if(!interactive){
-      plotrange <- apply(rbind(tcsres1[,c('x','y','z')],tcsres2[,c('x','y','z')]),2,range)
+  if(!interactive){
+    plotrange <- apply(rbind(tcsres1[,c('x','y','z')],tcsres2[,c('x','y','z')]),2,range)
 
     if(length(fill)<3)
 
-      if(dim(Voverlap)[1]>3){
-        vol(Voverlap, col=col[3], new=new, fill=TRUE,
+    if(dim(Voverlap)[1]>3){
+      vol(Voverlap, col=col[3], new=new, fill=TRUE,
           xlim=plotrange[,'x'], ylim=plotrange[,'y'], 
           zlim=plotrange[,'z'], lwd=lwd, ...)
-        vol(tcsres1, col=col[1], fill=fill, lwd=lwd, new=FALSE)
-        vol(tcsres2, col=col[2], fill=fill, lwd=lwd, new=FALSE)
-      }else{
-        vol(tcsres1, col=col[1], lwd=lwd, new=new, fill=fill,
+      vol(tcsres1, col=col[1], fill=fill, lwd=lwd, new=FALSE)
+      vol(tcsres2, col=col[2], fill=fill, lwd=lwd, new=FALSE)
+    }else{
+      vol(tcsres1, col=col[1], lwd=lwd, new=new, fill=fill,
           xlim=plotrange[,'x'], ylim=plotrange[,'y'], 
           zlim=plotrange[,'z'], ...)
-        vol(tcsres2, col=col[2], lwd=lwd, fill = fill, new=FALSE)
-      }
-	}
+      vol(tcsres2, col=col[2], lwd=lwd, fill = fill, new=FALSE)
+    }
+  }
 	
     
 ##########

--- a/tests/testthat/test-voloverlap.R
+++ b/tests/testthat/test-voloverlap.R
@@ -1,0 +1,72 @@
+library(pavo)
+context("voloverlap")
+
+test_that("tcs", {
+  data(sicalis)
+
+  vm_sicalis <- vismodel(sicalis)
+  tcs_sicalis <- colspace(vm_sicalis)
+  vol_sicalis <- voloverlap(tcs_sicalis, tcs_sicalis)
+
+  expect_length(vol_sicalis, 5)
+  expect_equal(vol_sicalis$vboth, 1)
+  expect_equal(vol_sicalis$vol1, vol_sicalis$vol2)
+})
+
+test_that("Dataframe", {
+  hrep <- rbind(c( 1,  1,  0),
+                c(-1,  0,  0),
+                c( 0, -1,  0),
+                c( 0,  0, -1),
+                c(-1, -1, -1))
+  qux <- rbind(c( 2,  0,  0),
+               c( 3,  1,  0),
+               c( 4,  0,  1),
+               c(-7, -1, -1))
+  
+  expect_error(voloverlap(hrep, qux), "dimnames")
+  
+  colnames(hrep) <- c("x", "y", "z")
+  colnames(qux)  <- c("x", "y", "z")
+  
+  vol <- voloverlap(hrep, qux)
+  
+  expect_length(vol, 5)
+  expect_equal(vol$vol1, 2.5/3)
+  expect_equal(vol$vol2, 1)
+})
+
+test_that("Symmetric", {
+  hrep <- rbind(c( 1,  1,  0),
+                c(-1,  0,  0),
+                c( 0, -1,  0),
+                c( 0,  0, -1),
+                c(-1, -1, -1))
+  qux <- rbind(c( 2,  0,  0),
+               c( 3,  1,  0),
+               c( 4,  0,  1),
+               c(-7, -1, -1))
+  
+  colnames(hrep) <- c("x", "y", "z")
+  colnames(qux)  <- c("x", "y", "z")
+
+  vol_hq <- voloverlap(hrep, qux )
+  vol_qh <- voloverlap(qux,  hrep)
+  
+  expect_equal(vol_hq$overlapvol, vol_qh$overlapvol)
+  expect_equal(vol_hq$vsmallest,  vol_qh$vsmallest)
+  expect_equal(vol_hq$vboth,      vol_hq$vboth)
+
+})
+
+test_that("Plane", {
+  
+  data(sicalis)
+  
+  vm_sicalis <- vismodel(sicalis)
+  tcs_sicalis <- colspace(vm_sicalis)
+  
+  plane_sicalis <- tcs_sicalis[1:3,]
+  
+  expect_error(suppressWarnings(voloverlap(plane_sicalis, plane_sicalis), "error code 1"))
+})


### PR DESCRIPTION
Let me start by saying that I may be completely wrong here and please let me know if that's the case.

I happen to compute a lot of volume overlaps on big `tcs` objects and it takes a lot of time.

`profvis` revealed that most of this time is spent on the `redundant` function. My understanding is that this function removes *redundant* (duh) lines from the input.

However, I think in the case of data points in `tcs`, it is highly unlikely to find redundant lines / colinear vertices. This step is correct in the general case but given the nature of the data here, it will probably never be useful.

Hence this PR where I remove the calls to `redundant` and slightly simplify the code to increase readability.

The speed up was measure with the `microbenchmark` package using the following code (I tested with other input data as well):

```r
library(pavo)
library(profvis)
library(microbenchmark)

data(sicalis)

vm_sicalis <- vismodel(sicalis)
tcs_sicalis <- colspace(vm_sicalis)

profvis(pavo::voloverlap(tcs_sicalis, tcs_sicalis))

# This step is here to ensure the function has been compiled before starting
# the benchmark
pavo::voloverlap(tcs_sicalis, tcs_sicalis)
voloverlap(tcs_sicalis, tcs_sicalis)

microbenchmark(pavo::voloverlap(tcs_sicalis, tcs_sicalis),
               voloverlap(tcs_sicalis, tcs_sicalis))
```


(PS: I realise that in the case where `tcsres1==tcsres2`, it is faster to directly use `convhulln`. This is just because I needed a dataset to perform benchmarks)