### PR TITLE
Fix warning in summary.colspace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ MAJOR CHANGES
 
 MINOR FEATURES AND BUG FIXES 
 
+* fixed harmless warning when summary.colspace() was used on a tcs object
+* `by` argument in merge.rspec() is no longer ignored
 * fixed bug in voloverlap() when plot = TRUE
 * fixed bug in vismodel() when transmission has more than one column
 * fixed bug in vismodel() that applied von Kries correction to achromatic channel

--- a/R/internal.R
+++ b/R/internal.R
@@ -6,8 +6,8 @@
   # {
   # message('package ', dQuote('rgl'), ' not found; attempting install...')
   # install.packages('rgl',dep=TRUE)
-  
-  # if(!require('rgl',character.only = TRUE)) 
+
+  # if(!require('rgl',character.only = TRUE))
     # stop(dQuote('rgl'), " package is required and could not be installed; please install and try again")
     # }
 # }
@@ -17,7 +17,7 @@
 ##################################
 
 newreceptornoise.neural <- function(dat, n, weber, weber.ref, res){
-	
+
   reln <- n/sum(n)
   v <- weber*sqrt(reln[weber.ref])
   e <- setNames(v/sqrt(reln), colnames(dat))
@@ -31,7 +31,7 @@ newreceptornoise.neural <- function(dat, n, weber, weber.ref, res){
 
   # get those combinations of ei and prod(ei)^2
 
-  num1 <- setNames(apply(n1combs, 2, function(x) prod(e[x])^2), 
+  num1 <- setNames(apply(n1combs, 2, function(x) prod(e[x])^2),
     apply(n1combs, 2, paste, collapse=""))
 
   # remaining 2 combinations (second part numerator)
@@ -39,7 +39,7 @@ newreceptornoise.neural <- function(dat, n, weber, weber.ref, res){
 
   # f_d and f_e
 
-  deltaqiqj <- lapply(1:length(num1), function(y) 
+  deltaqiqj <- lapply(1:length(num1), function(y)
     t(apply(res, 1, function(x)
       dat[x[1], n2combs[,y]] - dat[x[2], n2combs[,y]] ))
       )
@@ -65,7 +65,7 @@ newreceptornoise.neural <- function(dat, n, weber, weber.ref, res){
   # all n-1 combinations
   dcombs <- combn(colnames(dat),dim(dat)[2]-1)
 
-  den <- setNames(apply(dcombs, 2, function(x) prod(e[x])^2), 
+  den <- setNames(apply(dcombs, 2, function(x) prod(e[x])^2),
     apply(dcombs, 2, paste, collapse=""))
 
   denominator <- sum(den)
@@ -74,16 +74,16 @@ newreceptornoise.neural <- function(dat, n, weber, weber.ref, res){
   # DELTA S #
   ###########
 
-  sqrt(numerator/denominator)  
+  sqrt(numerator/denominator)
   }
 
 
 
 newreceptornoise.quantum <- function(dat, n, weber, weber.ref, res, qndat){
-	
+
   reln <- n/sum(n)
   v <- weber*sqrt(reln[weber.ref])
-  
+
   ept1 <- setNames(v^2/reln, colnames(dat))
   ept2 <- 2/t(apply(res, 1, function(x) qndat[x[1], ] + qndat[x[2], ] ))
   e <- sqrt(sweep(ept2, 2, ept1, "+"))
@@ -98,7 +98,7 @@ newreceptornoise.quantum <- function(dat, n, weber, weber.ref, res, qndat){
 
   # get those combinations of ei and prod(ei)^2
 
-  num1 <- do.call('rbind', lapply(1:dim(res)[1], function(z) 
+  num1 <- do.call('rbind', lapply(1:dim(res)[1], function(z)
     apply(n1combs, 2, function(x) prod(e[z,x])^2)))
   colnames(num1) <- apply(n1combs, 2, paste, collapse="")
 
@@ -107,7 +107,7 @@ newreceptornoise.quantum <- function(dat, n, weber, weber.ref, res, qndat){
 
   # f_d and f_e
 
-  deltaqiqj <- lapply(1:dim(n1combs)[2], function(y) 
+  deltaqiqj <- lapply(1:dim(n1combs)[2], function(y)
     t(apply(res, 1, function(x)
       dat[x[1], n2combs[,y]] - dat[x[2], n2combs[,y]] ))
       )
@@ -116,7 +116,7 @@ newreceptornoise.quantum <- function(dat, n, weber, weber.ref, res, qndat){
 
   # (f_d-f_e)^2
 
-  num2 <- do.call('cbind',lapply(deltaqiqj, function(x) 
+  num2 <- do.call('cbind',lapply(deltaqiqj, function(x)
     apply(x, 1, function(z) diff(z)^2)))
 
   # (e_abc)^2*(f_d-f_e)^2
@@ -134,7 +134,7 @@ newreceptornoise.quantum <- function(dat, n, weber, weber.ref, res, qndat){
   # all n-1 combinations
   dcombs <- combn(colnames(dat),dim(dat)[2]-1)
 
-  den <- do.call('rbind', lapply(1:dim(res)[1], function(z) 
+  den <- do.call('rbind', lapply(1:dim(res)[1], function(z)
     apply(dcombs, 2, function(x) prod(e[z,x])^2)))
   colnames(den) <- apply(dcombs, 2, paste, collapse="")
 
@@ -201,43 +201,43 @@ lab2d <- function(coord1, coord2){
 
 # CIE2000 colour distance for CIELCh (LOLWAT)
 cie2000 <- function(coord1, coord2){
-  
+
   # Lightness difference
   dL <- coord2['L'] - coord1['L']
-  
+
   # Mean lightness
   mL <- (coord2['L'] + coord1['L'])/2
-  
+
   # Chroma difference
   dC <- coord2['C'] - coord1['C']
-  
+
   # Mean chroma
   mC <- (coord2['C'] + coord1['C'])/2
-  
+
   # Hue difference
   if(coord1['h'] - coord2['h'] <= 180)
     dh <- coord2['h'] - coord1['h']
   else if(coord1['h'] - coord2['h'] > 180 & coord2['h'] <= coord1['h'])
-    dh <- coord2['h'] + coord1['h'] + 360 
+    dh <- coord2['h'] + coord1['h'] + 360
   else if(coord1['h'] - coord2['h'] > 180 & coord2['h'] > coord1['h'])
     dh <- coord2['h'] + coord1['h'] - 360
-  
+
   # Mean hue
   if(abs(coord2['h'] - coord1['h']) <= 180)
     mh <- (coord2['h'] + coord1['h'])/2
   else if(abs(coord2['h'] - coord1['h']) > 180 & coord2['h'] + coord1['h'] < 360)
-    mh <- (coord2['h'] + coord1['h'] + 360)/2 
+    mh <- (coord2['h'] + coord1['h'] + 360)/2
   else if(abs(coord2['h'] - coord1['h']) > 180 & coord2['h'] + coord1['h'] >= 360)
     mh <- (coord2['h'] + coord1['h'] - 360)/2
-  
+
   t <- 1 - (0.17 * cos(mh - 30)) + (0.24 * cos(2 * mh)) + (0.32 * cos(3 * mh + 6)) - (0.2 * cos(4 * mh - 63))
-    
+
   sL <- 1 + ((0.17 * (mL - 50)^2) / sqrt(20 + (mL - 50)^2))
   sC <-  1 + 0.045 * mC
   sH <- 1 + 0.015 * mC * t
-  
+
   Rt <- -2 * sqrt(mC^7 / (mC^7 + 25^7)) * sin(60 * exp(-1 * (((mh - 275)/25)^2)))
-  
+
   as.numeric(round(sqrt((dL/sL)^2 + (dC/sC)^2 + (dh/sH)^2 + (Rt * (dC/sC) * (dh/sH)))), 7)
 }
 
@@ -256,7 +256,7 @@ bloc2d <- function(coord1, coord2){
 
 huedisp <- function(tcsres){
   ind=t(combn(nrow(tcsres),2))
-  apply(ind,1, function(x)	
+  apply(ind,1, function(x)
 	 acos((cos(tcsres[x[1],'h.phi'])*cos(tcsres[x[2],'h.phi'])*cos(tcsres[x[1],'h.theta'] -
 	 tcsres[x[2],'h.theta'])) + (sin(tcsres[x[1],'h.phi'])*sin(tcsres[x[2],'h.phi'])))
      )
@@ -266,58 +266,55 @@ huedisp <- function(tcsres){
 tcssum <- function(tcsres){
   # centroid
   centroid <- colMeans(tcsres[c('u','s','m','l')])
-  
+
   # color span
   colspan.m <- mean(dist(tcsres[,c('x','y','z')]))
   colspan.v <- var(dist(tcsres[,c('x','y','z')]))
-  
+
   # color volume
   if(nrow(tcsres)>3)
        {
        c.vol <- convhulln(tcsres[,c('x','y','z')],"FA")$vol
        }else{
          c.vol<-NA}
-  
+
   # relative color volume
   if(nrow(tcsres)>3)
        {
-       totaltetra <- setNames(data.frame(diag(4)), c('u','s','m','l'))
-       class(totaltetra) <- c('vismodel', 'data.frame')
-       attr(totaltetra, 'relative') <- TRUE
-       attr(totaltetra, 'conenumb') <- 4
-       cstt <- colspace(totaltetra, 'tcs')
-       tot.c.vol <- convhulln(cstt[,c('x','y','z')],"FA")$vol
+       # Exact formula for the volume of a regular tetrahedron inscribed in a
+       # circle of radius (3/4)
+       tot.c.vol <- (3/sqrt(6))^3 / (6*sqrt(2))
        rel.c.vol <- c.vol/tot.c.vol
        }else{
          rel.c.vol<-NA}
-  
+
   # hue disparity
   hdisp.m <- mean(huedisp(tcsres))
   hdisp.v <- var(huedisp(tcsres))
-  
+
   # summary of achieved chroma
   mean.ra <- mean(tcsres$r.achieved)
   max.ra  <-  max(tcsres$r.achieved)
-  
+
   res.c <- c(centroid,c.vol, rel.c.vol, colspan.m,colspan.v,hdisp.m, hdisp.v, mean.ra,max.ra)
   names(res.c) <- c('centroid.u', 'centroid.s', 'centroid.m', 'centroid.l',
                   'c.vol', 'rel.c.vol', 'colspan.m', 'colspan.v', 'huedisp.m', 'huedisp.v',
                   'mean.ra', 'max.ra')
-  
+
   res.c
 }
 
-# TODO (Tom): These are a couple of functions that do what should be simple things in an 
+# TODO (Tom): These are a couple of functions that do what should be simple things in an
 # ugly way because my maths/programming is bad. Needs to be fixed.
 
 # Calculate hexagon hue angle (in degrees, moving clockwise, with 1200 as 0)
 # in the colour hexagon
 angle360 <- function(x, y){
-  
+
   theta <- 90 - (atan2(y, x) * (180/pi))
   if(theta < 0)
     theta <- theta + 360
-  
+
   theta
 
 }


### PR DESCRIPTION
This issue was reported to me by a labmate.

Reprex:

``` r
library(pavo)
data(sicalis)
vis_sicalis = vismodel(sicalis, visual = "avg.uv", achromatic = "ch.dc", 
                       qcatch = "Qi")
tcs_sicalis = colspace(vis_sicalis)
summary(tcs_sicalis)
#> Colorspace & visual model options:
#>  * Colorspace: tcs 
#>  * Quantal catch: Qi 
#>  * Visual system, chromatic: avg.uv 
#>  * Visual system, achromatic: ch.dc 
#>  * Illuminant: ideal, scale = 1 (von Kries color correction not applied) 
#>  * Background: ideal 
#>  * Relative: TRUE 
#> 
#> Warning in colspace(totaltetra, "tcs"): input is not a "vismodel" object
#> and argument "qcatch" is undefined; assuming quantum catch are not
#> transformed (i.e. qcatch="Qi")
#>            centroid.u centroid.s centroid.m centroid.l        c.vol
#> all.points  0.1213574 0.04834918  0.3886637  0.4416298 9.071221e-05
#>               rel.c.vol  colspan.m   colspan.v huedisp.m   huedisp.v
#> all.points 0.0004189818 0.07683295 0.002304218 0.1116872 0.004764701
#>              mean.ra    max.ra
#> all.points 0.8066033 0.9061528
```

You can also see this error in the vignette.

This was caused by the fact we did not specify a valid `qcatch` attribute when building a fake volume from the edges of the tetrahedron to compute `rel.c.vol`. 

Because the volume of the tetrahedron does not change, this strikes me as something that should be added in the function instead of being computed each time. So I added the formula. Feel free to check this gives the exact same result.
