### PR TITLE
Simplify irrad/flux conversion functions

### DIFF
--- a/R/irrad2flux.R
+++ b/R/irrad2flux.R
@@ -13,23 +13,17 @@
 
 irrad2flux <- function(rspecdata){
 
-if(!is.rspec(rspecdata))
-  stop('not an object of class rspec')
+  if(!is.rspec(rspecdata))
+    stop('not an object of class rspec')
 
   nam <- names(rspecdata)
-  wl_index <- which(names(rspecdata)=='wl')
-  wl <- rspecdata[,wl_index]
-  #rspecdata <- rspecdata[,-wl_index]	
+  wl <- rspecdata[, nam=='wl']
+
   K <- 0.01/(6.626*2.998*6.02308)
   
-  res <- sapply(1:ncol(rspecdata), function(z) rspecdata[,z] * wl * K )
-  res <- data.frame(res)
-  names(res) <- nam
-  class(res) <- c('rspec', 'data.frame')
-  
-  res[,'wl'] <- wl
-  
-  res
+  rspecdata[, nam!="wl"] <- rspecdata[, nam!="wl"] * wl * K
+
+  return(rspecdata)
 }
 
 

--- a/R/irrad2flux.R
+++ b/R/irrad2flux.R
@@ -30,24 +30,17 @@ irrad2flux <- function(rspecdata){
 #' @rdname irrad2flux
 #' @return a converted \code{rspec} object
 
-
 flux2irrad <- function(rspecdata){
 
-if(!is.rspec(rspecdata))
-  stop('not an object of class rspec')
+  if(!is.rspec(rspecdata))
+    stop('not an object of class rspec')
 
   nam <- names(rspecdata)
-  wl_index <- which(names(rspecdata)=='wl')
-  wl <- rspecdata[,wl_index]
-  #rspecdata <- rspecdata[,-wl_index]	
+  wl <- rspecdata[, nam=="wl"]
+
   K <- 0.01/(6.626*2.998*6.02308)
   
-  res <- sapply(1:ncol(rspecdata), function(z) rspecdata[,z] / (wl * K) )
-  res <- data.frame(res)
-  names(res) <- nam
-  class(res) <- c('rspec', 'data.frame')
+  rspecdata[, nam!="wl"] <- rspecdata[, nam!="wl"] / (wl * K)
   
-  res[,'wl'] <- wl
-  
-  res
+  return(rspecdata)
 }

--- a/R/irrad2flux.R
+++ b/R/irrad2flux.R
@@ -1,9 +1,10 @@
 #' Converts between irradiance and photon (quantum) flux
 #'
-#' Some spectrometers will give illuminant values in units of irradiance (uWatt * cm^-2),
-#' but physiological models require illuminants in units of photon (quantum) flux 
-#' (umol * s^-1 * m^-2). The functions \code{irrad2flux} and \code{flux2irrad} allows for
-#' easy conversion of \code{rspec} objects between these units.
+#' Some spectrometers will give illuminant values in units of irradiance 
+#' (uWatt * cm^-2), but physiological models require illuminants in units of 
+#' photon (quantum) flux (umol * s^-1 * m^-2). The functions \code{irrad2flux} 
+#' and \code{flux2irrad} allows for easy conversion of \code{rspec} objects
+#' between these units.
 #'
 #' @param rspecdata (required) a rspec object containing illuminant values.
 #' @return a converted \code{rspec} object.
@@ -28,7 +29,6 @@ irrad2flux <- function(rspecdata){
 
 
 #' @rdname irrad2flux
-#' @return a converted \code{rspec} object
 
 flux2irrad <- function(rspecdata){
 

--- a/R/irrad2flux.R
+++ b/R/irrad2flux.R
@@ -15,10 +15,10 @@
 irrad2flux <- function(rspecdata){
 
   if(!is.rspec(rspecdata))
-    stop('not an object of class rspec')
+    stop("not an object of class rspec")
 
   nam <- names(rspecdata)
-  wl <- rspecdata[, nam=='wl']
+  wl <- rspecdata[, nam=="wl"]
 
   K <- 0.01/(6.626*2.998*6.02308)
   
@@ -33,7 +33,7 @@ irrad2flux <- function(rspecdata){
 flux2irrad <- function(rspecdata){
 
   if(!is.rspec(rspecdata))
-    stop('not an object of class rspec')
+    stop("not an object of class rspec")
 
   nam <- names(rspecdata)
   wl <- rspecdata[, nam=="wl"]


### PR DESCRIPTION
- Remove apply functions. Arithmetic operations are already vectorized on dataframes
- Re-use the same object for the output so we don't have to specify names and class
- Remove duplicated "value" line in doc
- Wrap to 80 char, always use double quotes and indent test
