### PR TITLE
Simplify summary.rspec and fix S7 and H5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,9 +7,12 @@ NEW FEATURES
 
 MAJOR CHANGES
 * getspecf (and the argument fast=TRUE in getspec) have been deprecated
+* summary.rspec() returned incorrect values for S7. If you use S7, please re-run
+your analyses
 
 MINOR FEATURES AND BUG FIXES 
 
+* summary.rspec() now properly outputs `NA` for monotonically decreasing spectra
 * fixed warning when subset.rspec was provided with a logical vector
 * fixed harmless warning when summary.colspace() was used on a tcs object
 * `by` argument in merge.rspec() is no longer ignored

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -183,7 +183,7 @@ select <- (1:ncol(object))[-wl_index]
 object <- object[ , select, drop=FALSE]
 
 
-output.mat <- matrix (nrow=(dim(object)[2]), ncol=23)
+output.mat <- matrix(nrow=ncol(object), ncol=23)
 
 # Three measures of brightness
 B1 <- sapply(object, sum)

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -282,9 +282,7 @@ S5B <- colSums(object[Q1, ])
 
 S5 <- sqrt((S5R-S5G)^2+(S5Y-S5B)^2)
 
-H4 <- atan(((S5Y-S5B)/B1)/((S5R-S5G)/B1))
-#H4 <- atan2((S5R-S5G)/B1, (S5Y-S5B)/B1)
-#H4 <- atan2(S5R-S5G, S5Y-S5B)
+H4 <- atan2(S5Y-S5B, S5R-S5G)
 
 # Carotenoid chroma
 

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -166,26 +166,13 @@ wl <- object[,wl_index]
 # object <- object[,-wl_index]
 
 # set WL min & max
+lambdamin <- max(wlmin, min(wl))
+lambdamax <- min(wlmax, max(wl))
 
-if(is.null(wlmin)){
-  lambdamin <- min(wl)
-  }else{
-    if(wlmin < min(wl))
-      stop('wlmin is smaller than the range of spectral data')
-
-    lambdamin <- wlmin
-    }
-
-# lambdamax <- max(wl)
-
- if(is.null(wlmax)){
-   lambdamax <- max(wl)
-   }else{
-     if(wlmax > max(wl))
-       stop('wlmax is larger than the range of spectral data')
-
-     lambdamax <- wlmax
-     }
+if (!is.null(wlmin) && lambdamin > wlmin)
+  stop("wlmin is smaller than the range of spectral data")
+if (!is.null(wlmax) && lambdamax < wlmax)
+  stop("wlmax is larger than the range of spectral data")
 
 # restrict to range of wlmin:wlmax
 object <- object[which(wl==lambdamin):which(wl==lambdamax),]

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -192,6 +192,10 @@ B2 <- sapply(object, mean)
 
 B3 <- sapply(object, max)
 
+Rmin <- sapply(object, min)
+
+Rmid <- (B3 + Rmin) / 2
+
 # Chromas
 
 # Red
@@ -277,14 +281,25 @@ R450 <- as.numeric(object[which(wl==450), ])
 R700 <- as.numeric(object[which(wl==700), ])
 Carotchroma <- (R450-R700)/R700
 
+# H3
+index_Rmid <- sapply(1:ncol(object), function(x) {
+  which.min(abs(object[,x] - Rmid[x]))
+})
+H3 <- wl[index_Rmid]
+
 # S7
 
-sum_min_mid <- apply(object, 2, function(x)
-                     sum(x[which.min(x):round((which.max(x) + which.min(x))/2)]))
-sum_mid_max <- apply(object, 2, function(x)
-                     sum(x[round((which.max(x) + which.min(x))/2):which.max(x)]))
+S7 <- sapply(1:ncol(object), function(col) {
+  spec <- object[,col]
+  index_Rmid_spec <- index_Rmid[col]
+  spec_low <- spec[1:index_Rmid_spec]
+  spec_high <- spec[index_Rmid_spec:length(spec)]
 
-S7 <- (sum_min_mid - sum_mid_max)/(B1)
+  return(sum(spec_low) - sum(spec_high))
+
+})
+
+S7 <- S7/B1
 
 
 # S3
@@ -297,8 +312,6 @@ S3 <- sapply(pmindex, function(x) sum(object[minus50[x]:plus50[x],x]))/B1
 
 
 # Spectral saturation
-Rmin <- sapply(object, min)
-
 S2 <- B3/Rmin #S2
 
 S6 <- B3-Rmin # S6
@@ -307,20 +320,6 @@ S8 <- S6/B2 # S8
 
 # lambda Rmax hue
 H1 <- wl[max.col(t(object), ties.method='first')]
-
-# H3
-# limit to 400-700 nm range to avoid spurious UV peaks
-#  how about we don't do that?
-# H3object <- object[wl %in% 400:700, , drop = FALSE]
-# H3wl <- wl[wl %in% c(400:700)]
-# lambdaRmin <- wl[apply(object, 2, which.min)]  # H3
-# Rmid <- round((H1+lambdaRmin)/2)
-RmidH3 <- (Rmin + B3) / 2
-H3 <- sapply(1:ncol(object), function(x) {
-  which.min(abs(object[,x] - RmidH3[x]))
-})
-H3 <- wl[H3]
-
 
 # H2
 diffsmooth <- apply(object,2,diff)

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -330,8 +330,7 @@ H1 <- wl[max.col(t(object), ties.method='first')]
 # H3wl <- wl[wl %in% c(400:700)]
 # lambdaRmin <- wl[apply(object, 2, which.min)]  # H3
 # Rmid <- round((H1+lambdaRmin)/2)
-RmaxH3 <- sapply(object, max)
-RmidH3 <- (Rmin + RmaxH3) / 2
+RmidH3 <- (Rmin + B3) / 2
 H3 <- sapply(1:ncol(object), function(x) {
   which.min(abs(object[,x] - RmidH3[x]))
 })

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -326,19 +326,19 @@ H3 <- wl[H3]
 diffsmooth <- apply(object,2,diff)
 
 lambdabmaxneg <- wl[apply(diffsmooth,2,which.min)] #H2
-  lambdabmaxneg[which(apply(diffsmooth,2,min) > 0)] <- NA
+lambdabmaxneg[apply(diffsmooth,2,min) > 0] <- NA
 
 # S4
 bmaxneg <- abs(apply(diffsmooth,2,min)) #S4
-  bmaxneg[which(apply(diffsmooth,2,min) > 0)] <- NA
+bmaxneg[apply(diffsmooth,2,min) > 0] <- NA
 
 # S10
 S10 <- S8*bmaxneg #S10
- S10[which(apply(diffsmooth,2,min) > 0)] <- NA
+S10[apply(diffsmooth,2,min) > 0] <- NA
 
 # H5
 lambdabmax <- wl[apply(diffsmooth,2,which.max)] #H5
-  lambdabmax[which(apply(diffsmooth,2,which.max) < 0)] <- NA
+lambdabmax[apply(diffsmooth,2,which.max) < 0] <- NA
 
 
 # Add remaining variables to output

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -308,7 +308,7 @@ S7 <- S7/B1
 S3 <- sapply(1:ncol(object), function(col) {
   spec <- object[,col]
   H1_spec <- H1[col]
-  sum(spec[wl>(H1_spec-50) & wl<(H1_spec+50)])
+  sum(spec[wl>=(H1_spec-50) & wl<=(H1_spec+50)])
 })
 S3 <- S3/B1
 

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -301,9 +301,9 @@ Rmin <- sapply(object, min)
 
 S2 <- B3/Rmin #S2
 
-S8  <- (B3-Rmin)/B2 # S8
-
 S6 <- B3-Rmin # S6
+
+S8 <- S6/B2 # S8
 
 # lambda Rmax hue
 H1 <- wl[max.col(t(object), ties.method='first')]

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -200,7 +200,7 @@ Rmid <- (B3 + Rmin) / 2
 
 # Red
 if(lambdamin <= 605 & lambdamax >= 700){
-  Redchromamat <- object[which(wl==605):which(wl==700),] # red 605-700nm inclusive
+  Redchromamat <- object[which(wl==605):which(wl==700), , drop = FALSE] # red 605-700nm inclusive
   Redchroma <- colSums(Redchromamat)/B1 # S1 red
   output.mat[, 9] <- Redchroma
 }else{
@@ -209,7 +209,7 @@ if(lambdamin <= 605 & lambdamax >= 700){
 
 # Yellow
 if(lambdamin <= 550 & lambdamax >= 625){
-  Yellowchromamat <- object[which(wl==550):which(wl==625),] #yellow 550-625nm
+  Yellowchromamat <- object[which(wl==550):which(wl==625), , drop = FALSE] #yellow 550-625nm
   Yellowchroma <- colSums(Yellowchromamat)/B1 # S1 yellow
   output.mat[, 8] <- Yellowchroma
 }else{
@@ -218,7 +218,7 @@ if(lambdamin <= 550 & lambdamax >= 625){
 
 # Green
 if(lambdamin <= 510 & lambdamax >= 605){
-  Greenchromamat <- object[which(wl==510):which(wl==605),] # green 510-605nm inlusive
+  Greenchromamat <- object[which(wl==510):which(wl==605), , drop = FALSE] # green 510-605nm inlusive
   Greenchroma <- colSums(Greenchromamat)/B1 # S1 green
   output.mat[, 7] <- Greenchroma
   }else{
@@ -227,7 +227,7 @@ if(lambdamin <= 510 & lambdamax >= 605){
 
 # Blue
 if(lambdamin <= 400 & lambdamax >= 510){
-  Bluechromamat <- object[which(wl==400):which(wl==510),] # blue 400-510nm inclusive
+  Bluechromamat <- object[which(wl==400):which(wl==510), , drop = FALSE] # blue 400-510nm inclusive
   Bluechroma <- colSums(Bluechromamat)/B1 # S1 blue
   output.mat[, 6] <- Bluechroma
   }else{
@@ -236,7 +236,7 @@ if(lambdamin <= 400 & lambdamax >= 510){
 
 # UV
 if(lambdamin <= 400 & lambdamax >=400){
-  UVchromamat <- object[which(wl==lambdamin):which(wl==400),]
+  UVchromamat <- object[which(wl==lambdamin):which(wl==400), , drop = FALSE]
   UVchroma <- colSums(UVchromamat)/B1 # S1 UV
   output.mat [, 4] <- UVchroma
   }else{
@@ -249,7 +249,7 @@ if(lambdamin > 300 & lambdamin < 400){
 
 # Violet
 if(lambdamin <= 415 & lambdamax >= 415){
-  Vchromamat <- as.matrix(object[which(wl==lambdamin):which(wl==415),])
+  Vchromamat <- object[which(wl==lambdamin):which(wl==415), , drop = FALSE]
   Vchroma <- colSums(Vchromamat)/B1 # S1 Violet
   output.mat[, 5] <- Vchroma
 }else{
@@ -268,10 +268,10 @@ Q2 <- which(wl==segmts[2]):which(wl==segmts[3])
 Q3 <- which(wl==segmts[3]):which(wl==segmts[4])
 Q4 <- which(wl==segmts[4]):which(wl==segmts[5])
 
-S5R <- colSums(object[Q4, ])
-S5Y <- colSums(object[Q3, ])
-S5G <- colSums(object[Q2, ])
-S5B <- colSums(object[Q1, ])
+S5R <- colSums(object[Q4, , drop = FALSE])
+S5Y <- colSums(object[Q3, , drop = FALSE])
+S5G <- colSums(object[Q2, , drop = FALSE])
+S5B <- colSums(object[Q1, , drop = FALSE])
 
 S5 <- sqrt((S5R-S5G)^2+(S5Y-S5B)^2)
 

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -196,7 +196,7 @@ B3 <- sapply(object, max)
 
 # Red
 if(lambdamin <= 605 & lambdamax >= 700){
-  Redchromamat <- as.matrix(object[which(wl==605):which(wl==700),]) # red 605-700nm inclusive
+  Redchromamat <- object[which(wl==605):which(wl==700),] # red 605-700nm inclusive
   Redchroma <- colSums(Redchromamat)/B1 # S1 red
   output.mat[, 9] <- Redchroma
 }else{
@@ -205,7 +205,7 @@ if(lambdamin <= 605 & lambdamax >= 700){
 
 # Yellow
 if(lambdamin <= 550 & lambdamax >= 625){
-  Yellowchromamat <- as.matrix(object[which(wl==550):which(wl==625),]) #yellow 550-625nm
+  Yellowchromamat <- object[which(wl==550):which(wl==625),] #yellow 550-625nm
   Yellowchroma <- colSums(Yellowchromamat)/B1 # S1 yellow
   output.mat[, 8] <- Yellowchroma
 }else{
@@ -214,7 +214,7 @@ if(lambdamin <= 550 & lambdamax >= 625){
 
 # Green
 if(lambdamin <= 510 & lambdamax >= 605){
-  Greenchromamat <- as.matrix(object[which(wl==510):which(wl==605),]) # green 510-605nm inlusive
+  Greenchromamat <- object[which(wl==510):which(wl==605),] # green 510-605nm inlusive
   Greenchroma <- colSums(Greenchromamat)/B1 # S1 green
   output.mat[, 7] <- Greenchroma
   }else{
@@ -223,7 +223,7 @@ if(lambdamin <= 510 & lambdamax >= 605){
 
 # Blue
 if(lambdamin <= 400 & lambdamax >= 510){
-  Bluechromamat <- as.matrix(object[which(wl==400):which(wl==510),]) # blue 400-510nm inclusive
+  Bluechromamat <- object[which(wl==400):which(wl==510),] # blue 400-510nm inclusive
   Bluechroma <- colSums(Bluechromamat)/B1 # S1 blue
   output.mat[, 6] <- Bluechroma
   }else{
@@ -232,7 +232,7 @@ if(lambdamin <= 400 & lambdamax >= 510){
 
 # UV
 if(lambdamin <= 400 & lambdamax >=400){
-  UVchromamat <- as.matrix(object[which(wl==lambdamin):which(wl==400),])
+  UVchromamat <- object[which(wl==lambdamin):which(wl==400),]
   UVchroma <- colSums(UVchromamat)/B1 # S1 UV
   output.mat [, 4] <- UVchroma
   }else{
@@ -255,7 +255,7 @@ if(lambdamin <= 415 & lambdamax >= 415){
 
 # Segment-based variables
 
-segmts <- trunc(as.numeric(quantile(lambdamin:lambdamax)))
+segmts <- trunc(quantile(lambdamin:lambdamax, names = FALSE))
 
 Q1 <- which(wl==segmts[1]):which(wl==segmts[2])
 Q2 <- which(wl==segmts[2]):which(wl==segmts[3])

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -1,25 +1,25 @@
 #' Colorimetric variables
 #'
-#' Calculates all 23 colorimetric variables reviewed in 
+#' Calculates all 23 colorimetric variables reviewed in
 #' Montgomerie (2006).
 #'
 #' @param object (required) a data frame, possibly an object of class \code{rspec},
 #' with a column with wavelength data, named 'wl', and the remaining column containing
 #' spectra to process.
-#' @param subset Either \code{FALSE} (the default), \code{TRUE}, or a character vector. 
-#' If \code{FALSE}, all variables calculated are returned. If \code{TRUE}, only a subset 
-#' of the complete output (composed of B2, S8 and H1; the variables described in 
-#' Andersson and Prager 2006) are returned. Finally, a user-specified string of variable 
+#' @param subset Either \code{FALSE} (the default), \code{TRUE}, or a character vector.
+#' If \code{FALSE}, all variables calculated are returned. If \code{TRUE}, only a subset
+#' of the complete output (composed of B2, S8 and H1; the variables described in
+#' Andersson and Prager 2006) are returned. Finally, a user-specified string of variable
 #' names can be used in order to filter and show only those variables.
 #' @param wlmin,wlmax minimum and maximum used to define the range of wavelengths used in
 #' calculations (default is to use entire range in the \code{rspec} object).
 #' @param ... class consistency (ignored)
-#' 
-#' @return A data frame containing either 23 or 5 (\code{subset = TRUE}) variables described 
-#' in Montgomerie (2006) with spectra name as row names. 
-#' The colorimetric variables calculated by this function are 
+#'
+#' @return A data frame containing either 23 or 5 (\code{subset = TRUE}) variables described
+#' in Montgomerie (2006) with spectra name as row names.
+#' The colorimetric variables calculated by this function are
 #' described in Montgomerie (2006) with corrections included in the README CLR
-#' file from the May 2008 distribution of the CLR software. Authors should reference 
+#' file from the May 2008 distribution of the CLR software. Authors should reference
 #' both this package,Montgomerie (2006), and the original reference(s).
 #' Description and notes on the measures:
 #'
@@ -33,11 +33,11 @@
 #'
 #' B3 (Intensity): Maximum relative reflectance (Reflectance at wavelength of maximum
 #' reflectance). Note that may be sensitive to noise near the peak. REF 1, 5, 6
-#' 
+#'
 #' S1 (Chroma): Relative contribution of a spectral range to the total brightness (B1)
-#' S1 is arbitrarily divided in 6 measures of chroma based on the wavelength ranges 
-#' normally associated with specific hues. The values are calculated using the 
-#' following ranges: S1U (UV, if applicable): lambda min-400nm; 
+#' S1 is arbitrarily divided in 6 measures of chroma based on the wavelength ranges
+#' normally associated with specific hues. The values are calculated using the
+#' following ranges: S1U (UV, if applicable): lambda min-400nm;
 #' S1V (Violet) lambda min-415nm; S1B (Blue) 400nm-510nm; S1G (Green) 510nm-605nm;
 #' S1Y (Yellow) 550nm-625nm; S1R (Red) 605nm-lambda max. REF 2, 7, 8, 11-13
 #'
@@ -45,16 +45,16 @@
 #' Proper interpretation of this value may be difficult for spectra with multiple
 #' peaks in the range of interest. REF 1
 #'
-#' S3 (Chroma): Reflectance over the Rmax +- 50nm range divided by B1. Values for peaks 
-#' within 50nm of either the minimum or maximum range of the data will not be comparable 
-#' since the area under the curve for the area of interest will not always 
-#' be based on the same wavelength range. Therefore, S3 should be interpreted 
+#' S3 (Chroma): Reflectance over the Rmax +- 50nm range divided by B1. Values for peaks
+#' within 50nm of either the minimum or maximum range of the data will not be comparable
+#' since the area under the curve for the area of interest will not always
+#' be based on the same wavelength range. Therefore, S3 should be interpreted
 #' with caution for peaks in the UV or Red range. REF 11
 #'
 #' S4 (Spectral purity): |bmaxneg| , calculated by approximating the derivative
 #' of the spectral curve. As such, it is very sensitive to noise and should only
 #' be considered when data is adequately smoothed. NAs are returned for curves which
-#' do not, at any range of wavelength, decrease in intensity. Therefore, reflectance 
+#' do not, at any range of wavelength, decrease in intensity. Therefore, reflectance
 #' curves for brown and red surfaces, for example, should not generate a values. REF 1
 #'
 #' S5 (Chroma): Similar in design to segment classification measures (see Montgomerie 2006
@@ -62,21 +62,21 @@
 #'
 #' S6 (Contrast): Rmax - Rmin. Because it uses both Rmin and Rmax, this measure may be
 #' sensitive to spectral noise. REF 5, 6
-#' 
+#'
 #' S7 (Spectral saturation): Relative reflectance between the area around the peak with
 #' reflectance equal to or larger to half of that of the peak (an approximation to the
-#' full-width at half maxima. See Montgomerie (2006) for details). Somewhat sensitive 
+#' full-width at half maxima. See Montgomerie (2006) for details). Somewhat sensitive
 #' to noise and can be misleading when more than one maxima and/or minima are present.
 #' REF 3, 9
 #'
 #' S8 (Chroma): (Rmax - Rmin)/B2. Because it uses both Rmin and Rmax, this measure may be
 #' sensitive to spectral noise. REF 3, 13
 #'
-#' S9 (Carotenoid chroma): (R450 - R700)/R700. Should only be used when the color 
+#' S9 (Carotenoid chroma): (R450 - R700)/R700. Should only be used when the color
 #' of the surface is clearly due to carotenoid pigmentation and R450 is lower than
 #' R700. Could be sensitive to noise. REF 8
-#' 
-#' S10 (Peaky chroma): (Rmax - Rmin)/B2 x |bmaxneg|. Should be used with properly 
+#'
+#' S10 (Peaky chroma): (Rmax - Rmin)/B2 x |bmaxneg|. Should be used with properly
 #' smoothed curves. REF 7
 #'
 #' H1 (Peak wavelength, hue): Wavelength of maximum reflectance. May be sensitive to noise
@@ -89,28 +89,28 @@
 #'
 #' H4 (Hue): Similar in design to segment classification measures see Montgomerie
 #' (2006) for details. REF 10
-#' 
+#'
 #' H5 (Hue): Wavelength at bmax. Sensitive to noise and may be variable if there is
 #' more than one maxima and minima. REF 5
 #' @note If minimum wavelength is over 400, UV chroma is not computed.
 #' @note Variables which compute bmax and bmaxneg should be used with caution, for they
 #' rely on smoothed curves to remove noise, which would otherwise result in spurious
 #' results. Make sure chosen smoothing parameters are adequate.
-#' @note Smoothing affects only B3, S2, S4, S6, S10, H2, and H5 calculation. All other 
-#' variables can be reliably extracted using non-smoothed data. 
-#' 
+#' @note Smoothing affects only B3, S2, S4, S6, S10, H2, and H5 calculation. All other
+#' variables can be reliably extracted using non-smoothed data.
+#'
 #' @export
-#' 
+#'
 #' @examples \dontrun{
 #' data(sicalis)
 #' summary(sicalis)
 #' summary(sicalis, subset = TRUE)
 #' summary(sicalis, subset = c('B1', 'H4'))
 #' }
-#' 
+#'
 #' @author Pierre-Paul Bitton \email{bittonp@@windsor.ca}, Rafael Maia \email{rm72@@zips.uakron.edu}
-#' 
-#' @references Montgomerie R. 2006. Analyzing colors. In Hill, G.E, and McGraw, K.J., eds. 
+#'
+#' @references Montgomerie R. 2006. Analyzing colors. In Hill, G.E, and McGraw, K.J., eds.
 #' Bird Coloration. Volume 1 Mechanisms and measurements. Harvard University Press, Cambridge, Massachusetts.
 #' @references References describing variables:
 #'
@@ -172,7 +172,7 @@ if(is.null(wlmin)){
   }else{
     if(wlmin < min(wl))
       stop('wlmin is smaller than the range of spectral data')
-      
+
     lambdamin <- wlmin
     }
 
@@ -210,34 +210,34 @@ B3 <- sapply(object, max)
 # Red
 if(lambdamin <= 605 & lambdamax >= 700){
   Redchromamat <- as.matrix(object[which(wl==605):which(wl==700),]) # red 605-700nm inclusive
-  Redchroma <- as.vector(apply(Redchromamat,2,sum))/B1 # S1 red
+  Redchroma <- colSums(Redchromamat)/B1 # S1 red
   output.mat[, 9] <- Redchroma
 }else{
   warning('cannot calculate red chroma; wavelength range not between 605 and 700 nm', call.=FALSE)
-}	
-  
-# Yellow  
+}
+
+# Yellow
 if(lambdamin <= 550 & lambdamax >= 625){
   Yellowchromamat <- as.matrix(object[which(wl==550):which(wl==625),]) #yellow 550-625nm
-  Yellowchroma <- as.vector(apply(Yellowchromamat,2,sum))/B1 # S1 yellow
+  Yellowchroma <- colSums(Yellowchromamat)/B1 # S1 yellow
   output.mat[, 8] <- Yellowchroma
 }else{
   warning('cannot calculate yellow chroma; wavelength range not between 550 and 625 nm', call.=FALSE)
 }
 
-# Green  
+# Green
 if(lambdamin <= 510 & lambdamax >= 605){
   Greenchromamat <- as.matrix(object[which(wl==510):which(wl==605),]) # green 510-605nm inlusive
-  Greenchroma <- (apply(Greenchromamat,2,sum))/B1 # S1 green
+  Greenchroma <- colSums(Greenchromamat)/B1 # S1 green
   output.mat[, 7] <- Greenchroma
   }else{
   warning('cannot calculate green chroma; wavelength range not between 510 and 605 nm', call.=FALSE)
 }
 
-# Blue 
+# Blue
 if(lambdamin <= 400 & lambdamax >= 510){
   Bluechromamat <- as.matrix(object[which(wl==400):which(wl==510),]) # blue 400-510nm inclusive
-  Bluechroma <- (apply(Bluechromamat,2,sum))/B1 # S1 blue
+  Bluechroma <- colSums(Bluechromamat)/B1 # S1 blue
   output.mat[, 6] <- Bluechroma
   }else{
   warning('cannot calculate blue chroma; wavelength range not between 400 and 510 nm', call.=FALSE)
@@ -246,7 +246,7 @@ if(lambdamin <= 400 & lambdamax >= 510){
 # UV
 if(lambdamin <= 400 & lambdamax >=400){
   UVchromamat <- as.matrix(object[which(wl==lambdamin):which(wl==400),])
-  UVchroma <- (apply(UVchromamat,2,sum))/B1 # S1 UV
+  UVchroma <- colSums(UVchromamat)/B1 # S1 UV
   output.mat [, 4] <- UVchroma
   }else{
   warning('cannot calculate UV chroma; wavelength range not below 400 nm', call.=FALSE)
@@ -259,12 +259,12 @@ if(lambdamin > 300 & lambdamin < 400){
 # Violet
 if(lambdamin <= 415 & lambdamax >= 415){
   Vchromamat <- as.matrix(object[which(wl==lambdamin):which(wl==415),])
-  Vchroma <- (apply(Vchromamat,2,sum))/B1 # S1 Violet
-  output.mat[, 5] <- Vchroma  
+  Vchroma <- colSums(Vchromamat)/B1 # S1 Violet
+  output.mat[, 5] <- Vchroma
 }else{
   warning('cannot calculate violet chroma; wavelength below 415 nm', call.=FALSE)
 }
-  
+
 
 # Segment-based variables
 
@@ -275,10 +275,10 @@ Q2 <- which(wl==segmts[2]):which(wl==segmts[3])
 Q3 <- which(wl==segmts[3]):which(wl==segmts[4])
 Q4 <- which(wl==segmts[4]):which(wl==segmts[5])
 
-S5R <- apply(as.data.frame(object[Q4, ]), 2, sum) 
-S5Y <- apply(as.data.frame(object[Q3, ]), 2, sum) 
-S5G <- apply(as.data.frame(object[Q2, ]), 2, sum) 
-S5B <- apply(as.data.frame(object[Q1, ]), 2, sum) 
+S5R <- colSums(object[Q4, ])
+S5Y <- colSums(object[Q3, ])
+S5G <- colSums(object[Q2, ])
+S5B <- colSums(object[Q1, ])
 
 S5 <- sqrt((S5R-S5G)^2+(S5Y-S5B)^2)
 
@@ -294,9 +294,9 @@ Carotchroma <- (R450-R700)/R700
 
 # S7
 
-sum_min_mid <- apply(object, 2, function(x) 
+sum_min_mid <- apply(object, 2, function(x)
                      sum(x[which.min(x):round((which.max(x) + which.min(x))/2)]))
-sum_mid_max <- apply(object, 2, function(x) 
+sum_mid_max <- apply(object, 2, function(x)
                      sum(x[round((which.max(x) + which.min(x))/2):which.max(x)]))
 
 S7 <- (sum_min_mid - sum_mid_max)/(B1)
@@ -323,7 +323,7 @@ S6 <- B3-Rmin # S6
 # lambda Rmax hue
 H1 <- wl[max.col(t(object), ties.method='first')]
 
-# H3 
+# H3
 # limit to 400-700 nm range to avoid spurious UV peaks
 #  how about we don't do that?
 # H3object <- object[wl %in% 400:700, , drop = FALSE]
@@ -370,9 +370,9 @@ lambdabmax <- wl[apply(diffsmooth,2,which.max)] #H5
   output.mat[, 15] <- S7
   output.mat[, 16] <- S8
   output.mat[, 17] <- Carotchroma
-  output.mat[, 18] <- S10 
+  output.mat[, 18] <- S10
   output.mat[, 19] <- H1
-  output.mat[, 20] <- lambdabmaxneg 
+  output.mat[, 20] <- lambdabmaxneg
   output.mat[, 21] <- H3 # Rmid
   output.mat[, 22] <- H4
   output.mat[, 23] <- lambdabmax
@@ -382,8 +382,8 @@ lambdabmax <- wl[apply(diffsmooth,2,which.max)] #H5
 
 color.var <- data.frame(output.mat, row.names=names(object))
 
-names(color.var) <- c("B1", "B2", "B3", "S1U", "S1V", "S1B", "S1G", 
-                      "S1Y", "S1R", "S2", "S3", "S4", "S5", "S6", "S7", "S8", 
+names(color.var) <- c("B1", "B2", "B3", "S1U", "S1V", "S1B", "S1G",
+                      "S1Y", "S1R", "S2", "S3", "S4", "S5", "S6", "S7", "S8",
                       "S9", "S10", "H1", "H2", "H3", "H4", "H5")
 
 colvarnames <- names(color.var)

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -325,20 +325,23 @@ H3 <- wl[H3]
 # H2
 diffsmooth <- apply(object,2,diff)
 
+# Spectra that are monotically increasing or decreasing
+incr <- apply(diffsmooth,2,min) > 0
+decr <- apply(diffsmooth,2,max) < 0
+
 lambdabmaxneg <- wl[apply(diffsmooth,2,which.min)] #H2
-lambdabmaxneg[apply(diffsmooth,2,min) > 0] <- NA
+lambdabmaxneg[incr] <- NA
 
 # S4
 bmaxneg <- abs(apply(diffsmooth,2,min)) #S4
-bmaxneg[apply(diffsmooth,2,min) > 0] <- NA
+bmaxneg[incr] <- NA
 
 # S10
 S10 <- S8*bmaxneg #S10
-S10[apply(diffsmooth,2,min) > 0] <- NA
 
 # H5
 lambdabmax <- wl[apply(diffsmooth,2,which.max)] #H5
-lambdabmax[apply(diffsmooth,2,max) < 0] <- NA
+lambdabmax[decr] <- NA
 
 
 # Add remaining variables to output

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -338,7 +338,7 @@ S10[apply(diffsmooth,2,min) > 0] <- NA
 
 # H5
 lambdabmax <- wl[apply(diffsmooth,2,which.max)] #H5
-lambdabmax[apply(diffsmooth,2,which.max) < 0] <- NA
+lambdabmax[apply(diffsmooth,2,max) < 0] <- NA
 
 
 # Add remaining variables to output

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -256,6 +256,8 @@ if(lambdamin <= 415 & lambdamax >= 415){
   warning('cannot calculate violet chroma; wavelength below 415 nm', call.=FALSE)
 }
 
+# lambda Rmax hue
+H1 <- wl[max.col(t(object), ties.method='first')]
 
 # Segment-based variables
 
@@ -303,13 +305,12 @@ S7 <- S7/B1
 
 
 # S3
-
-plus50 <- apply(object,2,function(x) min(c(which.max(x)+50,which.max(wl))))
-minus50 <- apply(object,2,function(x) max(c(which.max(x)-50,which.min(wl))))
-pmindex <- 1:dim(object)[2]
-
-S3 <- sapply(pmindex, function(x) sum(object[minus50[x]:plus50[x],x]))/B1
-
+S3 <- sapply(1:ncol(object), function(col) {
+  spec <- object[,col]
+  H1_spec <- H1[col]
+  sum(spec[wl>(H1_spec-50) & wl<(H1_spec+50)])
+})
+S3 <- S3/B1
 
 # Spectral saturation
 S2 <- B3/Rmin #S2
@@ -317,9 +318,6 @@ S2 <- B3/Rmin #S2
 S6 <- B3-Rmin # S6
 
 S8 <- S6/B2 # S8
-
-# lambda Rmax hue
-H1 <- wl[max.col(t(object), ties.method='first')]
 
 # H2
 diffsmooth <- apply(object,2,diff)

--- a/tests/testthat/test-S3rspec.R
+++ b/tests/testthat/test-S3rspec.R
@@ -15,7 +15,7 @@ test_that("summary.rspec", {
   data(sicalis)
   
   expect_equal(dim(summary(sicalis)), c(21, 23))
-  expect_known_hash(summary(sicalis), "0103dbe6c2")
+  expect_known_hash(summary(sicalis), "445ac7b9b5")
   
   # Subset
   expect_named(summary(sicalis, subset = TRUE), c("B2", "S8", "H1"))

--- a/tests/testthat/test-S3rspec.R
+++ b/tests/testthat/test-S3rspec.R
@@ -1,0 +1,34 @@
+library(pavo)
+context('rspec')
+
+# File to test S3 functions related to the rspec class
+
+test_that("as.rspec", {
+  data(flowers)
+
+  flowers2 <- as.rspec(as.data.frame(flowers))
+  expect_s3_class(flowers2, "rspec")
+
+})
+
+test_that("summary.rspec", {
+  data(sicalis)
+  
+  expect_equal(dim(summary(sicalis)), c(21, 23))
+  expect_known_hash(summary(sicalis), "0103dbe6c2")
+  
+  # Subset
+  expect_named(summary(sicalis, subset = TRUE), c("B2", "S8", "H1"))
+  expect_named(summary(sicalis, subset = c("B1", "H4")), c("B1", "H4"))
+  
+  # Different wl ranges
+  expect_warning(summary(sicalis, wlmin = 500), "wavelength range not between")
+  expect_warning(summary(sicalis[1:200,]), "wavelength range not between")
+  expect_error(summary(sicalis, wlmax = 1000), "wlmax is larger")
+
+  # Test one spectrum rspec object
+  one_spec = sicalis[, c(1, 2)]
+  
+  expect_equal(dim(summary(one_spec)), c(1, 23))
+  
+})

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -5,8 +5,7 @@ test_that('Class assignment', {
   data(flowers)
   
   # Check rspec
-  flowers <- as.rspec(as.data.frame(flowers))
-  expect_is(flowers, "rspec")
+  # See test-S3rspec.R
   
   # Check vismodel
   vis.flowers <- vismodel(flowers, visual = 'apis')


### PR DESCRIPTION
This started as a minor clean up but I think I found some important bugs:

- H5 did not properly output `NA` when run on a monotonically decreasing function because of a typo (`which.max` instead of `max`). You can test with:

```r
wl = c(300:700)
spec1 = 30 / (1 + exp(-0.025 * (501-wl)))
specdf = as.rspec(dataframe("wl"=wl, "spec1"=spec1))
```

- S7 computed `(lambda(Rmin)+lambda(Rmax))/2` instead of `lambda((Rmin+Rmax)/2)`. Those 2 wavelengths are only equal for linear functions, which is not the case for spectra. I also think the documentation for S7 is not accurate and should be revised. More details on the dev channel.

As usual, some changes may be a matter of stylistic preference. Feel free to tell me if you disagree. I am totally okay with amending/rebasing/squashing/cherry-picking...

I have the feeling some things could be further simplified but I can't find anything better for now. I may come back to this function later. To do before this is ready to merge:

- [x] Check the documentation
- [x] Add some tests
- [x] Update changelog
