### PR TITLE
Simplify and refine spec2rgb and add tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ MINOR FEATURES AND BUG FIXES
 * better handling of subset data when using summary.colspace() and summary.vismodel()
 * fixed bug in coldist() when `noise = "quantum"` and `achro = TRUE` were used
 * fixed bug in jndplot() when `arrow = "none"` and `achro = TRUE`
+* spec2rgb() now takes into account the 390-400nm wavelength range into account when possible
 
 pavo 1.3.1
 ------------------------------------------------------------------------------

--- a/R/spec2rgb.R
+++ b/R/spec2rgb.R
@@ -41,7 +41,8 @@ if (length(wl_index > 0)){
 if(min(wl) > 400 | max(wl) < 700)
   stop('wavelength range does not capture the full visible range (400 to 700)')
 
-rspecdata <- rspecdata[which(wl==400):which(wl==700), , drop=FALSE]
+rspecdata <- rspecdata[wl>=390 & wl<=700, , drop=FALSE]
+wl <- wl[wl>=390 & wl<=700]
 names_rspecdata <- names(rspecdata)
 rspecdata <- as.matrix(rspecdata)
 
@@ -49,10 +50,7 @@ rspecdata <- as.matrix(rspecdata)
 # sens <- ciexyz[,1:4] #cie2
 sens <- ciexyz[,c(1,5:7)] #cie10
 
-# TEMP: removing wavelengths 390:400
-# TO DO: check if rspecdata starts at 400 or <400 and change this accordingly
-
-sens <- as.matrix(sens[which(sens$wl==400):which(sens$wl==700),])
+sens <- as.matrix(sens[match(wl, sens$wl),])
 
 # P2 <- sapply(1:ncol(rspecdata), function(x) rspecdata[, x] / sum(rspecdata[, x]))  # normalize to sum of 1
 # P2 <- rspecdata

--- a/R/spec2rgb.R
+++ b/R/spec2rgb.R
@@ -75,11 +75,7 @@ xyzmat <- rbind(c(3.240479, -1.537150, -0.498535),
 rgb1 <- tcrossprod(XYZ, xyzmat)
 
 # sRGB companding (e.g., see http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html)
-rgb1 <- lapply(1:ncol(rgb1), function(x) {
-  ifelse(rgb1[,x, drop=F] <= 0.0031308, 12.92*rgb1[,x, drop=F], 1.055*rgb1[,x, drop=F]^(1/2.4) - 0.055)
-  })
-
-rgb1 <- do.call(cbind, rgb1)
+rgb1 <- ifelse(rgb1 <= 0.0031308, 12.92 * rgb1, 1.055 * rgb1^(1/2.4) - 0.055)
 
 # clip RGB values outside {0-1}
 rgb1[rgb1 < 0] <- 0

--- a/R/spec2rgb.R
+++ b/R/spec2rgb.R
@@ -87,11 +87,8 @@ rgb1 <- do.call(cbind, rgb1)
 rgb1[rgb1 < 0] <- 0
 rgb1[rgb1 > 1] <- 1
 
-colrs <- rgb(red=rgb1[, 1], green=rgb1[, 2], blue=rgb1[, 3], alpha=alpha)
-
-#class(colrs) <- c('spec2rgb', 'character')
-
-names(colrs) <- names_rspecdata
+colrs <- rgb(red=rgb1[, 1], green=rgb1[, 2], blue=rgb1[, 3], alpha=alpha,
+             names = names_rspecdata)
 
 colrs
 

--- a/R/spec2rgb.R
+++ b/R/spec2rgb.R
@@ -6,23 +6,23 @@
 #' with a column with wavelength data, named 'wl', and the remaining column containing
 #' spectra to process.
 #' @param alpha alpha value to use for colors (defaults to 1, opaque).
-#' 
+#'
 #' @return A character vector of class \code{spec2rgb} consisting of hexadecimal color values
 #' for passing to further plotting functions.
-#' 
+#'
 #' @export
-#' 
+#'
 #' @examples \dontrun{
 #' data(teal)
 #' spec2rgb(teal)
-#' 
+#'
 #' # Plot data using estimated perceived color
 #' plot(teal, col = spec2rgb(teal), type = 'o')}
-#' 
+#'
 #' @author Chad Eliason \email{cme16@@zips.uakron.edu}
-#' 
+#'
 #' @references CIE(1932). Commission Internationale de l'Eclairage Proceedings, 1931. Cambridge: Cambridge University Press.
-#' @references Color matching functions obtained from Colour and Vision Research Laboratory 
+#' @references Color matching functions obtained from Colour and Vision Research Laboratory
 #' online data repository at \url{http://www.cvrl.org/}.
 #' @references \url{http://www.cs.rit.edu/~ncs/color/t_spectr.html}.
 
@@ -32,9 +32,9 @@ wl_index <- which(names(rspecdata)=='wl')
 if (length(wl_index > 0)){
   wl <- rspecdata[, wl_index]
   rspecdata <- as.data.frame(rspecdata[, -wl_index, drop=FALSE])
-    } else {
-    stop('No wavelengths supplied; no default')
-    }
+} else {
+  stop('No wavelengths supplied; no default')
+}
 
 # this should be changed later (interpolate?)
 
@@ -52,20 +52,20 @@ sens <- ciexyz[,c(1,5:7)] #cie10
 # TEMP: removing wavelengths 390:400
 # TO DO: check if rspecdata starts at 400 or <400 and change this accordingly
 
-sens <- sens[which(sens$wl==400):which(sens$wl==700),]
+sens <- as.matrix(sens[which(sens$wl==400):which(sens$wl==700),])
 
 # P2 <- sapply(1:ncol(rspecdata), function(x) rspecdata[, x] / sum(rspecdata[, x]))  # normalize to sum of 1
 # P2 <- rspecdata
 P2 <- rspecdata / 100  # scale to proportion of incident light
 
 # Convolute
-X <- apply(sens[, grep('x', names(sens))] * P2, 2, sum)
-Y <- apply(sens[, grep('y', names(sens))] * P2, 2, sum)
-Z <- apply(sens[, grep('z', names(sens))] * P2, 2, sum)
+# For all matrix products, crossprod is preferred over %*%. 
+# See https://stackoverflow.com/a/42777636
+XYZ <- crossprod(P2, sens[,2:4])
 
 # Scale by y(lambda)
-N <- sum(sens[, grep('y', names(sens))])  # normalization factor
-XYZ <- cbind(X, Y, Z) / N
+N <- sum(sens[, grep('y', colnames(sens))])  # normalization factor
+XYZ <- XYZ / N
 
 # transfer matrices for converting XYZ to RGB
 # source: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
@@ -73,15 +73,8 @@ XYZ <- cbind(X, Y, Z) / N
 xyzmat <- rbind(c(3.240479, -1.537150, -0.498535),
                 c(-0.969256, 1.875992, 0.041556),
                 c(0.055648, -0.204043, 1.057311))
-# CIE RGB
-# xyzmat <- rbind(c(2.3706743, -0.9000405, -0.4706338),
-#                 c(-0.5138850, 1.4253036, 0.0885814),
-#                 c(0.0052982, -0.0146949, 1.0093968))
 
-# xyz <- t(sapply(1:nrow(XYZ), function(x) XYZ[x, ] / sum(XYZ[x, ])))
-
-# rgb1 <- t(sapply(1:nrow(XYZ), function(x) xyzmat%*%as.matrix(XYZ[x, ])))
-rgb1 <- t(sapply(1:nrow(XYZ), function(x) {xyzmat %*% XYZ[x, ]}))
+rgb1 <- tcrossprod(XYZ, xyzmat)
 
 # sRGB companding (e.g., see http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html)
 rgb1 <- lapply(1:ncol(rgb1), function(x) {

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -24,3 +24,12 @@ test_that('Class assignment', {
   col.hex <- colspace(vis.hex, space = 'hex')
   expect_is(col.hex, 'colspace')
 })
+
+test_that("plot utilities", {
+  
+  data(sicalis)
+  expect_known_hash(spec2rgb(sicalis), "0d3e41a7b6")
+  
+  expect_error(spec2rgb(sicalis[300:nrow(sicalis),]), "full visible range")
+  expect_error(spec2rgb(sicalis[,-1]), "No wavelengths supplied")
+})


### PR DESCRIPTION
This PR simplifies `spec2rgb` quite a bit by leveraging the power of linear algebra operations. No need for apply/apply-like functions.

I also used this opportunity to address a `TODO`: `spec2rgb` now takes into account 390 to 400nm wavelengths as well when available.

I compared the output of this updated `spec2rgb` with the one from `master` on `teal[101:401,]`.