### PR TITLE
 Fix handling of relative=F df and properly test for quasi-equality 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,8 @@ MINOR FEATURES AND BUG FIXES
 * spec2rgb() now takes into account the 390-400 nm wavelength range into account when possible
 * as.rspec() no longer fails with tibbles
 * bin option of procspec() now works for all values of bins
-
+* non-relative quantum catches from dataframe object were not correctly scaled
+in "di", "tri", "categorical" and "coc" colspaces
 pavo 1.3.1
 ------------------------------------------------------------------------------
 

--- a/R/categorical.R
+++ b/R/categorical.R
@@ -71,7 +71,8 @@ categorical <- function(vismodeldata) {
     dat <- dat[, 1:4]
     names(dat) <- c("u", "s", "m", "l")
 
-    if (round(sum(rowSums(dat / apply(dat, 1, sum)))) != dim(dat)[1]) {
+    # Check that all rows sum to 1 (taking into account R floating point issue)
+    if (!isTRUE(all.equal(rowSums(dat), rep(1, nrow(dat)), check.attributes = FALSE))) {
       # dat <- dat/apply(dat, 1, sum)
       warning("Quantum catch are not relative, which may produce unexpected results", call. = FALSE)
       # attr(vismodeldata,'relative') <- TRUE

--- a/R/coc.R
+++ b/R/coc.R
@@ -1,78 +1,78 @@
-#' Color opponent coding model 
-#' 
+#' Color opponent coding model
+#'
 #' Calculates coordinates and colorimetric variables that represent reflectance spectra
 #' in the color opponent coding model of hymenopteran vision.
-#' 
+#'
 #' @param vismodeldata (required) quantum catch color data. Can be either the result
 #'  from \code{\link{vismodel}} or independently calculated data (in the form of a data frame
 #'  with three columns named 's', 'm', 'l', representing a trichromatic viewer).
-#' 
+#'
 #' @return A data frame of class \code{colspace} consisting of the following columns:
-#' @return \code{s}, \code{m}, \code{l}: the quantum catch data used to calculate 
+#' @return \code{s}, \code{m}, \code{l}: the quantum catch data used to calculate
 #'  the remaining variables.
 #' @return \code{x}, \code{y}: coordinates for the points in coc space
 #' @return \code{r.vec}: the r vector (saturation, distance from the center using
 #'  a city-block metric).
-#' 
+#'
 #' @examples \dontrun{
 #' data(flowers)
 #' vis.flowers <- vismodel(flowers, visual = 'apis', qcatch = 'Ei', relative = FALSE, vonkries = TRUE)
 #' coc.flowers <- colspace(vis.flowers, space = 'coc')
-#' } 
-#' 
+#' }
+#'
 #' @author Thomas White \email{thomas.white026@@gmail.com}
-#' 
+#'
 #' @export
-#' 
+#'
 #' @keywords internal
-#' 
+#'
 #' @references Backhaus W. (1991). Color opponent coding in the visual system
 #'  of the honeybee. Vision Research, 31, 1381-1397.
 
 coc <- function(vismodeldata){
-  
+
   dat <- vismodeldata
-  
+
   # if object is vismodel:
   if('vismodel' %in% attr(dat, 'class')){
-    
+
     # check if trichromat
     if(attr(dat, 'conenumb') < 3)
       stop('vismodel input is not trichromatic', call.=FALSE)
-    
+
     if(attr(dat, 'conenumb') > 3)
       warning('vismodel input is not trichromatic, considering first three receptors only', call.=FALSE)
-    
+
     if(attr(dat, 'relative'))
       stop("Quantum catches are relative, which is not required in the coc model", call.=FALSE)
-    
+
     if(attr(dat, 'qcatch') != 'Ei')  # todo: more flexible
       stop("Quantum catches are not hyperbolically transformed, as required for the coc model", call.=FALSE)
-    
+
     if(!isTRUE(attr(dat, 'vonkries')))
       stop("Quantum catches are not von-Kries transformed, as required for the coc model", call.=FALSE)
-    
+
   }
-  
+
   # if not, check if it has more (or less) than 3 columns
-  
+
   if(!('vismodel' %in% attr(dat, 'class'))){
-    
+
     if(ncol(dat) < 3)
-      stop('Input data is not a ',  dQuote('vismodel'), ' object and has fewer than three columns', call.=FALSE)	
+      stop('Input data is not a ',  dQuote('vismodel'), ' object and has fewer than three columns', call.=FALSE)
     if(ncol(dat) == 3)
       warning('Input data is not a ', dQuote('vismodel'), ' object; treating columns as quantum catch for ', dQuote('s'),', ',  dQuote('m'), ', and ', dQuote('l'), ' receptors, respectively', call.=FALSE)
-    
+
     if(ncol(dat) > 3)
       warning('Input data is not a ', dQuote('vismodel'), ' object *and* has more than three columns; treating the first three columns as quantum catch for ', dQuote('s'),', ',  dQuote('m'),', and ', dQuote('l'), ' receptors, respectively', call.=FALSE)
-    
+
     dat <- dat[, 1:3]
     names(dat) <- c('s', 'm', 'l')
-    
-    if(round(sum(rowSums(dat/apply(dat,1,sum)))) == dim(dat)[1])
+
+    if (isTRUE(all.equal(rowSums(dat), rep(1, nrow(dat)), check.attributes = FALSE)))
       stop("Quantum catches are relative, which is not required in the coc model and may produce unexpected results", call.=FALSE)
   }
-  
+
   if(all(c('s', 'm', 'l') %in% names(dat))){
     s <- dat[, 's']
     m <- dat[, 'm']
@@ -83,21 +83,21 @@ coc <- function(vismodeldata){
     m <- dat[, 2]
     l <- dat[, 3]
   }
-  
+
   # coordinates
-  x <- (-9.86 * s) + (7.7 * m) + (2.16 * l) 
-  y <- (-5.17 * s) + (20.25 * m) - (15.08 * l) 
-  
+  x <- (-9.86 * s) + (7.7 * m) + (2.16 * l)
+  y <- (-5.17 * s) + (20.25 * m) - (15.08 * l)
+
   # colorimetrics
   r.vec <- abs(x) + abs(y)  # city-block from origin
   #h.theta <- atan2(y, x)
-  
+
   res.p <- data.frame(s, m, l, x, y, r.vec, row.names = rownames(dat))
-  
+
   res <- res.p
-  
+
   class(res) <- c('colspace', 'data.frame')
-  
+
   # Descriptive attributes (largely preserved from vismodel)
   attr(res, 'clrsp') <- 'coc'
   attr(res, 'conenumb') <- 3
@@ -108,11 +108,11 @@ coc <- function(vismodeldata){
   attr(res,'background') <- attr(vismodeldata,'background')
   attr(res,'relative') <- attr(vismodeldata,'relative')
   attr(res, 'vonkries') <- attr(vismodeldata, 'vonkries')
-  
+
   # Data attributes
   attr(res, 'data.visualsystem.chromatic') <- attr(vismodeldata, 'data.visualsystem.chromatic')
   attr(res, 'data.visualsystem.achromatic') <- attr(vismodeldata, 'data.visualsystem.achromatic')
   attr(res, 'data.background') <- attr(vismodeldata, 'data.background')
-  
+
   res
 }

--- a/R/dispace.R
+++ b/R/dispace.R
@@ -71,7 +71,8 @@ dispace <- function(vismodeldata) {
     dat <- dat[, 1:2]
     names(dat) <- c("s", "l")
 
-    if (round(sum(rowSums(dat / apply(dat, 1, sum)))) != dim(dat)[1]) {
+    # Check that all rows sum to 1 (taking into account R floating point issue)
+    if (!isTRUE(all.equal(rowSums(dat), rep(1, nrow(dat)), check.attributes = FALSE))) {
       dat <- dat / apply(dat, 1, sum)
       warning("Quantum catch are not relative, and have been transformed", call. = FALSE)
       attr(vismodeldata, "relative") <- TRUE

--- a/R/hexagon.R
+++ b/R/hexagon.R
@@ -90,7 +90,7 @@ hexagon <- function(vismodeldata) {
     dat <- dat[, 1:3]
     names(dat) <- c("s", "m", "l")
 
-    if (round(sum(rowSums(dat / apply(dat, 1, sum)))) == dim(dat)[1]) {
+    if (isTRUE(all.equal(rowSums(dat), rep(1, nrow(dat)), check.attributes = FALSE))) {
       stop("Quantum catches are relative, which is not required in the hexagon model.", call. = FALSE)
     }
   }

--- a/R/trispace.R
+++ b/R/trispace.R
@@ -78,7 +78,8 @@ trispace <- function(vismodeldata) {
     dat <- dat[, 1:3]
     names(dat) <- c("s", "m", "l")
 
-    if (round(sum(rowSums(dat / apply(dat, 1, sum)))) != dim(dat)[1]) {
+    # Check that all rows sum to 1 (taking into account R floating point issue)
+    if (!isTRUE(all.equal(rowSums(dat), rep(1, nrow(dat)), check.attributes = FALSE))) {
       dat <- dat / apply(dat, 1, sum)
       warning("Quantum catch are not relative, and have been transformed.", call. = FALSE)
       attr(vismodeldata, "relative") <- TRUE

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -3,26 +3,58 @@ context('colspace')
 
 test_that('Receptor orders/names', {
   data(flowers)
-  
+
   # dichromat
   di <- sensmodel(c(440, 330))
   names(di) <- c('wl', 'l', 's')
   di.vis <- vismodel(flowers, visual = di)
-  di.space <- colspace(di.vis) 
+  di.space <- colspace(di.vis)
   expect_equal(di.vis, di.space[, 2:1], check.attributes = FALSE)
-  
+
   # trichromat
   tri <- sensmodel(c(550, 440, 330))
   names(tri) <- c('wl', 'l', 'm' ,'s')
   tri.vis <- vismodel(flowers, visual = tri)
-  tri.space <- colspace(tri.vis) 
+  tri.space <- colspace(tri.vis)
   expect_equal(tri.vis, tri.space[, 3:1], check.attributes = FALSE)
-  
+
   # tetrachromat
   tetra <- sensmodel(c(660, 550, 440, 330))
   names(tetra) <- c('wl', 'l', 'm', 's', 'u')
   tetra.vis <- vismodel(flowers, visual = tetra)
-  tetra.space <- colspace(tetra.vis) 
+  tetra.space <- colspace(tetra.vis)
   expect_equal(tetra.vis, tetra.space[, 4:1], check.attributes = FALSE)
-  
+
+})
+
+test_that("Relative quantum catches", {
+  data(flowers)
+
+  # dichromat
+  di <- sensmodel(c(440, 330))
+  names(di) <- c('wl', 'l', 's')
+
+  di_vis <- vismodel(flowers, visual = di)
+  di_vis_norel = vismodel(flowers, visual = di, relative = FALSE)
+  di_vis_noreldf = as.data.frame(di_vis_norel)
+
+  expect_warning(colspace(di_vis_norel), "not relative")
+  expect_warning(colspace(di_vis_noreldf), "not relative")
+
+  expect_equal(suppressWarnings(colspace(di_vis)), 
+               suppressWarnings(colspace(di_vis_norel)))
+
+  # trichromat
+  tri <- sensmodel(c(550, 440, 330))
+  names(tri) <- c('wl', 'l', 'm' ,'s')
+
+  tri_vis <- vismodel(flowers, visual = tri)
+  tri_vis_norel = vismodel(flowers, visual = tri, relative = FALSE)
+  tri_vis_noreldf = as.data.frame(tri_vis_norel)
+
+  expect_warning(colspace(tri_vis_norel), "not relative")
+  expect_warning(colspace(tri_vis_noreldf), "not relative")
+
+  expect_equal(suppressWarnings(colspace(tri_vis)), 
+               suppressWarnings(colspace(tri_vis_norel)))
 })


### PR DESCRIPTION
Quantum catches that were not relative were not properly scaled when providing a dataframe.

You can see this by running:

```r
data(flowers)
vis_flo = vismodel(flowers, relative = FALSE)
vis_flo = as.data.frame(vis_flo)
colspace(vis_flo, "tri")
```