### PR TITLE
Change all "=" for "<-" and start using goodpractice package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ r_build_args:
 r_check_args: 
 r_packages: rmarkdown
 # warnings_are_errors: false
+after_success:
+  - Rscript -e 'goodpractice::gp(checks = "lintr_assignment_linter")'
 notifications:
   email:
     on_success: never

--- a/R/aggplot.R
+++ b/R/aggplot.R
@@ -110,7 +110,7 @@ if (is.null(arg$lwd))
   lwd <- 1
 
 if (length(lwd) < ncol(cntplotspecs))
-   lwd <- rep(lwd, ncol(cntplotspecs))
+  lwd <- rep(lwd, ncol(cntplotspecs))
 
 # coloring for overlay plot & others
 if (!is.null(arg$lty))
@@ -120,7 +120,7 @@ if (is.null(arg$lty))
   lty <- 1
 
 if (length(lty) < ncol(cntplotspecs))
-   lty <- rep(lty, ncol(cntplotspecs))
+  lty <- rep(lty, ncol(cntplotspecs))
 
 if (length(shadecol) < ncol(cntplotspecs))
   shadecol <- rep(shadecol, ncol(cntplotspecs))
@@ -145,8 +145,7 @@ if (is.null(shadecol))
 if(is.null(lcol))
   lcol <- col_list
  
- shadecol = rgb(t(col2rgb(shadecol))/255, alpha=alpha)
- lcol = rgb(t(col2rgb(lcol))/255)
+ shadecol <- rgb(t(col2rgb(shadecol))/255, alpha=alpha)
 
 # plot polygons first...
 

--- a/R/cocplot.R
+++ b/R/cocplot.R
@@ -51,15 +51,15 @@ cocplot <- function(cocdata, labels = TRUE, labels.cex = 0.9,
   if(is.null(arg$pch))
     arg$pch <- 19  
   if(is.null(arg$xlim))
-    arg$xlim  = c(-12, 12)
+    arg$xlim <- c(-12, 12)
   if(is.null(arg$ylim))
-    arg$ylim  = c(-12, 12)
+    arg$ylim <- c(-12, 12)
   if(is.null(arg$xlab))
-    arg$xlab = ''
+    arg$xlab <- ''
   if(is.null(arg$ylab))
-    arg$ylab = ''
+    arg$ylab <- ''
   if(is.null(arg$bty))
-    arg$bty = 'n'
+    arg$bty <- 'n'
   
   # Plot
   arg$x <- cocdata$x

--- a/R/internal.R
+++ b/R/internal.R
@@ -255,7 +255,7 @@ bloc2d <- function(coord1, coord2){
 #####################
 
 huedisp <- function(tcsres){
-  ind=t(combn(nrow(tcsres),2))
+  ind <- t(combn(nrow(tcsres),2))
   apply(ind,1, function(x)
 	 acos((cos(tcsres[x[1],'h.phi'])*cos(tcsres[x[2],'h.phi'])*cos(tcsres[x[1],'h.theta'] -
 	 tcsres[x[2],'h.theta'])) + (sin(tcsres[x[1],'h.phi'])*sin(tcsres[x[2],'h.phi'])))

--- a/R/jndrot.R
+++ b/R/jndrot.R
@@ -60,8 +60,8 @@ jndrot <- function(jnd2xyzres, center=c('mean', 'achro'), ref1='l', ref2='u', ax
   vectormag <- function(x) sqrt(sum(x^2))
   vectornorm <- function(x) matrix(as.numeric(x/vectormag(x)), ncol=1)
   vectorcross <- function(a,b){
-    i = c(2,3,1)
-    j = c(3,1,2)
+    i <- c(2,3,1)
+    j <- c(3,1,2)
     a[i]*b[j] - a[j]*b[i]
   }
   

--- a/R/plotsmooth.R
+++ b/R/plotsmooth.R
@@ -128,7 +128,7 @@ mtext("Wavelength (nm)", side=1, outer=T, line=1)
 mtext("Reflectance (%)", side=2, outer=T, line=1)	
 }
 
-	nextplot = 2
+	nextplot <- 2
 		while (nextplot < ncol(bloc)+1) { 						
 			lines (rspecdata[,1],bloc[,nextplot],cex=0.1)
 			nextplot<- nextplot+1}

--- a/R/projplot.R
+++ b/R/projplot.R
@@ -32,8 +32,7 @@
 #'  visual systems and the evolution of color patterns: Sensory processing illuminates 
 #'  signal evolution. Evolution, 59(8), 1795-1818.
 
-projplot = function(tcsdata, ...)
-{
+projplot <- function(tcsdata, ...) {
 
 #oPar <- par(no.readonly=TRUE)
 oPar <- par('mar')
@@ -46,8 +45,8 @@ on.exit(par(oPar))
     # dat <- tcsdata
     # }
 
-points.theta=tcsdata[,'h.theta']
-points.phi=tcsdata[,'h.phi']
+points.theta <- tcsdata[,'h.theta']
+points.phi <- tcsdata[,'h.phi']
 
 n <- length(points.theta)
 

--- a/R/segplot.R
+++ b/R/segplot.R
@@ -56,15 +56,15 @@ segplot <- function(segdata, labels = TRUE, lab.cex = 0.9,
   if(is.null(arg$pch))
     arg$pch <- 19  
   if(is.null(arg$xlim))
-    arg$xlim  = c(-1, 1)
+    arg$xlim <- c(-1, 1)
   if(is.null(arg$ylim))
-    arg$ylim  = c(-1, 1)
+    arg$ylim <- c(-1, 1)
   if(is.null(arg$xlab))
-    arg$xlab = ' '
+    arg$xlab <- ' '
   if(is.null(arg$ylab))
-    arg$ylab = ' '
-  arg$bty = 'n'
-  arg$axes = FALSE
+    arg$ylab <- ' '
+  arg$bty <- 'n'
+  arg$axes <- FALSE
     
 # Plot
   arg$x <- segdata$MS

--- a/R/subset.rspec.R
+++ b/R/subset.rspec.R
@@ -55,7 +55,7 @@ subset.rspec <- function (x, subset, ...) {
   }
 
   # We don't drop the "wl" column if it exists, no matter what subset says.
-  res = x[, unique(c(wl_index, subsample))]
+  res <- x[, unique(c(wl_index, subsample))]
 
   class(res) <- c("rspec", "data.frame")
   

--- a/R/tcspace.R
+++ b/R/tcspace.R
@@ -115,8 +115,8 @@ tcspace <- function(vismodeldata){
   # S&P suggest values with reflectance lower than a treshold (0.05) not have 
   # hue & r. not implemented.
   
-  r.vec<- sqrt(x*x + y*y + z*z)
-  r.vec[r.vec==0] = NaN
+  r.vec <- sqrt(x*x + y*y + z*z)
+  r.vec[r.vec==0] <- NaN
   
   
   h.theta<- atan2(y,x)

--- a/R/tcsplot.R
+++ b/R/tcsplot.R
@@ -86,19 +86,18 @@ tcsplot<- function(tcsdata, size = 0.02, alpha = 1, col = 'black',
     
     # can't figure out how to change the character type
     
-    ttv = ttvertex
+    ttv <- ttvertex
     
-    cu = t(col2rgb('#984EA3')) / 255
-    cs = t(col2rgb('#377EB8')) / 255
-    cm = t(col2rgb('#4DAF4A')) / 255
-    cl = t(col2rgb('#E41A1C')) / 255
+    cu <- '#984EA3'
+    cs <- '#377EB8'
+    cm <- '#4DAF4A'
+    cl <- '#E41A1C'
     
     rgl::plot3d(unlist(ttv[c('xu','xs','xm','xl')]),
     		unlist(ttv[c('yu','ys','ym','yl')]),
     		unlist(ttv[c('zu','zs','zm','zl')]), type = 's', lit = F,
     		radius = vertexsize, box = F, axes = F, xlab = '', ylab = '', zlab = '',
-    		col = c(rgb(cu[1], cu[2], cu[3]), rgb(cs[1], cs[2], cs[3]), 
-    		rgb(cm[1], cm[2], cm[3]), rgb(cl[1], cl[2], cl[3])))
+    		col = c(cu, cs, cm, cl))
     
     rgl::segments3d(ttv[c('xu','xs')], ttv[c('yu','ys')], ttv[c('zu','zs')], 
       color = lcol, lwd = lwd)

--- a/tests/testthat/test-S3rspec.R
+++ b/tests/testthat/test-S3rspec.R
@@ -27,7 +27,7 @@ test_that("summary.rspec", {
   expect_error(summary(sicalis, wlmax = 1000), "wlmax is larger")
 
   # Test one spectrum rspec object
-  one_spec = sicalis[, c(1, 2)]
+  one_spec <- sicalis[, c(1, 2)]
   
   expect_equal(dim(summary(one_spec)), c(1, 23))
   

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -35,8 +35,8 @@ test_that("Relative quantum catches", {
   names(di) <- c('wl', 'l', 's')
 
   di_vis <- vismodel(flowers, visual = di)
-  di_vis_norel = vismodel(flowers, visual = di, relative = FALSE)
-  di_vis_noreldf = as.data.frame(di_vis_norel)
+  di_vis_norel <- vismodel(flowers, visual = di, relative = FALSE)
+  di_vis_noreldf <- as.data.frame(di_vis_norel)
 
   expect_warning(colspace(di_vis_norel), "not relative")
   expect_warning(colspace(di_vis_noreldf), "not relative")
@@ -49,8 +49,8 @@ test_that("Relative quantum catches", {
   names(tri) <- c('wl', 'l', 'm' ,'s')
 
   tri_vis <- vismodel(flowers, visual = tri)
-  tri_vis_norel = vismodel(flowers, visual = tri, relative = FALSE)
-  tri_vis_noreldf = as.data.frame(tri_vis_norel)
+  tri_vis_norel <- vismodel(flowers, visual = tri, relative = FALSE)
+  tri_vis_noreldf <- as.data.frame(tri_vis_norel)
 
   expect_warning(colspace(tri_vis_norel), "not relative")
   expect_warning(colspace(tri_vis_noreldf), "not relative")


### PR DESCRIPTION
Ultimately, I would like all `goodpractice` tests to be run but it's probably safer to go one step at a time.

More info [here](https://github.com/MangoTheCat/goodpractice).

Please note that there is a slight additional change. I think some convoluted operations on colours (switching back and forth between hex and rgb) were not necessary so I removed them completely instead of just updating the assignment operator. This concerns the `tcsplot` and `aggplot` functions. Tested with:

``` r
data(sicalis)
#> Warning in data(sicalis): data set 'sicalis' not found

aggplot(sicalis, by = 3)
#> Error in aggplot(sicalis, by = 3): could not find function "aggplot"

vis_sicalis = vismodel(sicalis)
#> Error in vismodel(sicalis): could not find function "vismodel"

tcs_sicalis = colspace(vis_sicalis)
#> Error in colspace(vis_sicalis): could not find function "colspace"

tcsplot(tcs_sicalis)
#> Error in tcsplot(tcs_sicalis): could not find function "tcsplot"
```

