### PR TITLE
Restore missing spaces in message about negative values

### DIFF
--- a/R/getspec.R
+++ b/R/getspec.R
@@ -214,7 +214,8 @@ getspec <- function(where = getwd(), ext = "txt", lim = c(300, 700), decimal = "
 
   # Negative value check
   if (any(final < 0, na.rm = TRUE)) {
-    message("\nThe spectral data contain", sum(final < 0, na.rm = TRUE), "negative value(s), which may produce unexpected results if used in models. Consider using procspec() to correct them.")
+    message("\nThe spectral data contain ", sum(final < 0, na.rm = TRUE),
+            " negative value(s), which may produce unexpected results if used in models. Consider using procspec() to correct them.")
   }
 
   final


### PR DESCRIPTION
I made a mistake in #114 and forgot to add spaces after removing `paste`.