### PR TITLE
Create new vignette with table summarizing all spectral shape descriptors

### DIFF
--- a/vignettes/open-biology.csl
+++ b/vignettes/open-biology.csl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB"><script xmlns="" id="custom-useragent-string"/>
+  <!-- The Royal Society, generated from "royal-society" metadata at https://github.com/citation-style-language/journals -->
+  <info>
+    <title>Open Biology</title>
+    <id>http://www.zotero.org/styles/open-biology</id>
+    <link href="http://www.zotero.org/styles/open-biology" rel="self"/>
+    <link href="http://www.zotero.org/styles/proceedings-of-the-royal-society-b" rel="independent-parent"/>
+    <link href="https://royalsociety.org/journals/authors/author-guidelines/" rel="documentation"/>
+    <category citation-format="numeric"/>
+    <category field="biology"/>
+    <eissn>2046-2441</eissn>
+    <updated>2017-01-06T04:50:22+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/vignettes/spectraldesc.Rmd
+++ b/vignettes/spectraldesc.Rmd
@@ -1,0 +1,54 @@
+---
+title: "Spectral shape descriptors"
+author: "Rafael Maia, Thomas White, Hugo Gruson, Pierre-Paul Bitton, Chad Eliason"
+date: "`r Sys.Date()`"
+output: html_document
+bibliography: table_montgomerie.bib
+csl: open-biology.csl
+---
+
+<style>
+tr:hover {
+  background-color: #eee;
+}
+</style>
+
+This table is adapted from @Montgomerie2006 and lists all spectral descriptors
+that are computed by the `summary` function in `pavo`.
+
+| Color variable | Names used | Formula | Reference |
+|:---------------|:-----------|:-------:|:---------:|
+| Brightness     | Total brightness, total reflectance, spectral intensity | $$B_1=B_T=\int_{\lambda_{min}}^{\lambda_{max}} R_i = \sum_{\lambda_{min}}^{\lambda_{max}} R_i$$ | @Andersson1999,@Andersson2002,@Ornborg2002,@Andersson1998,@Smiseth2001,@Saks2003,@Pryke2001,@Shawkey2003 |
+| | Mean brightness | $$B_2=\frac{\sum_{\lambda_{min}}^{\lambda_{max}} R_i}{n_w}=\frac{B_1}{n_w}$$ | @Delhey2003,@Siefferman2005 |
+| | Intensity | $$B_3=R_{max}$$ | @Andersson1999,@Keyser2000,@Keyser1999 |
+| Saturation | Chroma, reflectance ratio, spectral purity | $$S_1= \frac{\sum_{\lambda_a}^{\lambda_b} R_i}{\sum_{\lambda_{min}}^{\lambda_{max}} R_i} = \frac{\sum_{\lambda_a}^{\lambda_b} R_i}{B_1}$$ | @Ornborg2002,@Andersson1998,@Smiseth2001,@Siefferman2005,@Peters2004,@Shawkey2003 | 
+| | Spectral saturation | $$S_2 = \frac{R_{max}}{R_{min}}$$ | @Andersson1999 |
+| | Chroma | $$S_3 = \frac{\sum_{\lambda_{R_{max}}-50}^{\lambda_{R_{max}}+50} R_i}{B_1}$$ | @Shawkey2003 |
+| | Spectral purity | $$S_4 = \lvert b\text{max}_{neg}\lvert$$ | @Andersson1999 |
+| | Chroma | $$S_5=\sqrt{(B_r-B_g)^2+(B_y-B_b)^2}$$ | @Saks2003 |
+| | Constrast, amplitude | $$S_6 = R_{max} - R_{min}$$ | @Keyser2000,@Keyser1999 |
+| | Spectral saturation | $$S_7 = \frac{\left(\sum_{\lambda_{320}}^{\lambda_{R_{mid}}} R_i - \sum_{\lambda_{R_{mid}}}^{\lambda_{700}} R_i\right)}{B_1}$$ | @Andersson2002,@Pryke2001 |
+| | Chroma | $$S_8=\frac{R_{max}-R_{min}}{B_2}$$ | @Andersson2002,@Smiseth2001 |
+| | Carotenoid chroma | $$S_9=\frac{R_{\lambda_{700}}-R_{\lambda_{450}}}{R_{\lambda_{700}}}$$ | @Peters2004 |
+| | Peaky chroma | $$S_{10}=\lvert b\text{max}_{neg} \lvert\frac{R_{max}-R_{min}}{B_2}$$ | @Ornborg2002 | 
+| Hue | Hue, peak wavelength, spectral location | $$H_1=\lambda_{R_{max}}$$ | @Andersson1999,@Ornborg2002,@Andersson1998,@Delhey2003,@Smiseth2001,@Keyser2000,@Siefferman2005,@Shawkey2003 |
+| | Hue | $$H_2 = \lambda_{b\text{max}_{neg}}$$ | @Andersson1998,@Smiseth2001 |
+| | Hue | $$H_3 = \lambda_{R_{mid}}$$ | @Andersson2002,@Smiseth2001,@Pryke2001 |
+| | Hue | $$H_4 = \arctan\left(\frac{B_y-B_b}{B_r-B_g}\right)$$ | @Saks2003 |
+| | Hue | $$H_5 = \lambda_{b\text{max}_{pos}}$$ | @Keyser1999 |
+
+- $R_i$: percentage (or proportional) reflectance at the $i$th wavelength
+- $\lambda_{max}$, $\lambda_{min}$: upper and lower (respectively) limits of
+wavelengths
+- $n_w$: number of wavelength intervals used to calculate $B_T$
+- $R_{max}$, $R_{min}$: maximum and minimum percent reflectances, respectively
+- $\lambda_{R_{max}}$: wavelength at maximum reflectance
+- $b\text{max}_{neg}$, $b\text{max}_{pos}$: maximum negative and positive slopes
+of reflectance curve in a region of interest
+- $B_r$, $B_y$, $B_g$, $B_b$: total brightness in red ($r=625-700\,nm$), yellow
+($y=550-625\,nm$), green ($g=475-550\,nm$) and blue ($b=400-475\,nm$) segments
+of the spectrum
+- $\lambda_{R_{mid}}$: wavelength at the reflectance midpoint between $R_{max}$
+and $R_{min}$ (i.e., $\frac{R_{max}+R_{min}}{2}$)
+
+# References

--- a/vignettes/table_montgomerie.bib
+++ b/vignettes/table_montgomerie.bib
@@ -1,0 +1,217 @@
+@incollection{Montgomerie2006,
+  title = {Analyzing {{Colors}}},
+  volume = {1},
+  isbn = {978-0-674-01893-8},
+  volumes = {2},
+  booktitle = {Bird {{Coloration}}, {{Volume}} 1: {{Mechanisms}} and {{Measurements}}},
+  series = {Bird Coloration},
+  publisher = {{Harvard University Press}},
+  date = {2006-02},
+  pages = {640},
+  author = {Montgomerie, Robert},
+  editor = {Hill, Geoffrey E. and McGraw, Kevin J.}
+}
+
+@article{Andersson1999,
+  eprinttype = {jstor},
+  eprint = {3677129},
+  title = {Morphology of {{UV}} Reflectance in a Whistling-Thrush: Implications for the Study of Structural Colour Signalling in Birds},
+  volume = {30},
+  issn = {0908-8857},
+  doi = {10.2307/3677129},
+  shorttitle = {Morphology of {{UV Reflectance}} in a {{Whistling}}-{{Thrush}}},
+  number = {2},
+  journaltitle = {Journal of Avian Biology},
+  date = {1999},
+  pages = {193-204},
+  author = {Andersson, Staffan}
+}
+
+@article{Pryke2001,
+  title = {Agonistic Carotenoid Signalling in Male Red-Collared Widowbirds: Aggression Related to the Colour Signal of Both the Territory Owner and Model Intruder},
+  volume = {62},
+  issn = {0003-3472},
+  url = {http://www.sciencedirect.com/science/article/pii/S0003347201918044},
+  doi = {10.1006/anbe.2001.1804},
+  shorttitle = {Agonistic Carotenoid Signalling in Male Red-Collared Widowbirds},
+  number = {4},
+  journaltitle = {Animal Behaviour},
+  shortjournal = {Animal Behaviour},
+  urldate = {2018-05-09},
+  date = {2001-10-01},
+  pages = {695-704},
+  author = {Pryke, Sarah R. and Lawes, Michael J. and Andersson, Staffan}
+}
+
+@article{Andersson2002,
+  langid = {english},
+  title = {Multiple Receivers, Multiple Ornaments, and a Trade‐off between Agonistic and Epigamic Signaling in a Widowbird},
+  volume = {160},
+  issn = {0003-0147},
+  url = {https://www.journals.uchicago.edu/doi/10.1086/342817},
+  doi = {10.1086/342817},
+  number = {5},
+  journaltitle = {The American Naturalist},
+  urldate = {2018-07-12},
+  date = {2002-11-01},
+  pages = {683-691},
+  author = {Andersson, Staffan and Pryke, Sarah R. and Örnborg, Jonas and Lawes, Michael J. and Andersson, Malte}
+}
+
+@article{Keyser1999,
+  langid = {english},
+  title = {Condition–Dependent Variation in the Blue–Ultraviolet Coloration of a Structurally Based Plumage Ornament},
+  volume = {266},
+  issn = {0962-8452, 1471-2954},
+  url = {http://rspb.royalsocietypublishing.org/content/266/1421/771},
+  doi = {10.1098/rspb.1999.0704},
+  number = {1421},
+  journaltitle = {Proceedings of the Royal Society of London B: Biological Sciences},
+  urldate = {2018-08-31},
+  date = {1999-04-22},
+  pages = {771-777},
+  author = {Keyser, Amber J. and Hill, Geoffrey E.}
+}
+
+@article{Saks2003,
+  langid = {english},
+  title = {How Feather Colour Reflects Its Carotenoid Content},
+  volume = {17},
+  issn = {0269-8463, 1365-2435},
+  url = {http://doi.wiley.com/10.1046/j.1365-2435.2003.00765.x},
+  doi = {10.1046/j.1365-2435.2003.00765.x},
+  number = {4},
+  journaltitle = {Functional Ecology},
+  urldate = {2018-08-31},
+  date = {2003-08},
+  pages = {555-561},
+  author = {Saks, Lauri and McGraw, Kevin and Horak, Peeter}
+}
+
+@article{Shawkey2003,
+  langid = {english},
+  title = {Nanostructure Predicts Intraspecific Variation in Ultraviolet–Blue Plumage Colour},
+  volume = {270},
+  issn = {0962-8452, 1471-2954},
+  url = {http://rspb.royalsocietypublishing.org/content/270/1523/1455},
+  doi = {10.1098/rspb.2003.2390},
+  number = {1523},
+  journaltitle = {Proceedings of the Royal Society of London B: Biological Sciences},
+  urldate = {2018-08-31},
+  date = {2003-07-22},
+  pages = {1455-1460},
+  author = {Shawkey, Matthew D. and Estes, Anne M. and Siefferman, Lynn M. and Hill, Geoffrey E.},
+  eprinttype = {pmid},
+  eprint = {12965009}
+}
+
+@article{Peters2004,
+  langid = {english},
+  title = {Carotenoid-Based Bill Colour as an Indicator of Immunocompetence and Sperm Performance in Male Mallards},
+  volume = {17},
+  issn = {1420-9101},
+  url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1420-9101.2004.00743.x},
+  doi = {10.1111/j.1420-9101.2004.00743.x},
+  number = {5},
+  journaltitle = {Journal of Evolutionary Biology},
+  urldate = {2018-08-31},
+  date = {2004-09-01},
+  pages = {1111-1120},
+  author = {Peters, A. and Denk, A. G. and Delhey, K. and Kempenaers, B.}
+}
+
+@article{Siefferman2005,
+  title = {{{UV}}-Blue Structural Coloration and Competition for Nestboxes in Male Eastern Bluebirds},
+  volume = {69},
+  issn = {0003-3472},
+  url = {http://www.sciencedirect.com/science/article/pii/S000334720400329X},
+  doi = {10.1016/j.anbehav.2003.12.026},
+  number = {1},
+  journaltitle = {Animal Behaviour},
+  shortjournal = {Animal Behaviour},
+  urldate = {2018-08-31},
+  date = {2005-01-01},
+  pages = {67-72},
+  author = {Siefferman, Lynn and Hill, Geoffrey E.}
+}
+
+@article{Smiseth2001,
+  langid = {english},
+  title = {Is Male Plumage Reflectance Correlated with Paternal Care in Bluethroats?},
+  volume = {12},
+  issn = {1045-2249},
+  url = {https://academic.oup.com/beheco/article/12/2/164/239964},
+  doi = {10.1093/beheco/12.2.164},
+  number = {2},
+  journaltitle = {Behavioral Ecology},
+  shortjournal = {Behav Ecol},
+  urldate = {2018-08-31},
+  date = {2001-03-01},
+  pages = {164-170},
+  author = {Smiseth, Per T. and Örnborg, Jonas and Andersson, Staffan and Amundsen, Trond}
+}
+
+@article{Keyser2000,
+  langid = {english},
+  title = {Structurally Based Plumage Coloration Is an Honest Signal of Quality in Male Blue Grosbeaks},
+  volume = {11},
+  issn = {1045-2249},
+  url = {https://academic.oup.com/beheco/article/11/2/202/204765},
+  doi = {10.1093/beheco/11.2.202},
+  number = {2},
+  journaltitle = {Behavioral Ecology},
+  shortjournal = {Behav Ecol},
+  urldate = {2018-08-31},
+  date = {2000-03-01},
+  pages = {202-209},
+  author = {Keyser, Amber J. and Hill, Geoffrey E.}
+}
+
+@article{Delhey2003,
+  langid = {english},
+  title = {Paternity Analysis Reveals Opposing Selection Pressures on Crown Coloration in the Blue Tit ({{Parus}} Caeruleus)},
+  volume = {270},
+  issn = {0962-8452, 1471-2954},
+  url = {http://rspb.royalsocietypublishing.org/content/270/1528/2057},
+  doi = {10.1098/rspb.2003.2460},
+  number = {1528},
+  journaltitle = {Proceedings of the Royal Society of London B: Biological Sciences},
+  urldate = {2018-08-31},
+  date = {2003-10-07},
+  pages = {2057-2063},
+  author = {Delhey, Kaspar and Johnsen, Arild and Peters, Anne and Andersson, Staffan and Kempenaers, Bart},
+  eprinttype = {pmid},
+  eprint = {14561295}
+}
+
+@article{Andersson1998,
+  langid = {english},
+  title = {Ultraviolet Sexual Dimorphism and Assortative Mating in Blue Tits},
+  volume = {265},
+  issn = {0962-8452, 1471-2954},
+  url = {http://rspb.royalsocietypublishing.org/content/265/1395/445},
+  doi = {10.1098/rspb.1998.0315},
+  number = {1395},
+  journaltitle = {Proceedings of the Royal Society of London B: Biological Sciences},
+  urldate = {2018-08-31},
+  date = {1998-03-22},
+  pages = {445-450},
+  author = {Andersson, Staffan and Örnborg, Jonas and Andersson, Malte}
+}
+
+@article{Ornborg2002,
+  langid = {english},
+  title = {Seasonal Changes in a Ultraviolet Structural Colour Signal in Blue Tits, {{Parus}} Caeruleus},
+  volume = {76},
+  issn = {1095-8312},
+  url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1095-8312.2002.tb02085.x},
+  doi = {10.1111/j.1095-8312.2002.tb02085.x},
+  number = {2},
+  journaltitle = {Biological Journal of the Linnean Society},
+  urldate = {2018-08-31},
+  date = {2002-06-01},
+  pages = {237-245},
+  author = {Örnborg, Jonas and Andersson, Staffan and Griffith, Simon C. and Sheldon, Ben C.}
+}
+
+


### PR DESCRIPTION
I created a new vignette for this because it works well as a standalone resource and the main vignette is already quite large. We can easily merge them if you prefer though.

I think it has a great potential for many improvements in the future, such as adding small figures to visually explain what each variable represents. But it is already quite useful in its current form so I think it is ready to be merged.

Let me know if you want me to change anything!