### PR TITLE
Use oldrel, release and devel channels in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ addons:
 r_build_args: 
 r_check_args: 
 r_packages: rmarkdown
+jobs:
+  include:
+  - r: oldrel
+  - r: release
+  - r: devel
 # warnings_are_errors: false
 after_success:
   - Rscript -e 'goodpractice::gp(checks = c("lintr_assignment_linter", "truefalse_not_tf"))'


### PR DESCRIPTION
I'm not sure I got this right, let's have a look. This will prevents issues such as the one we are facing right now where checks do not work on all supported R versions.