### PR TITLE
Soft wrap code blocks and globally center figs with css

### DIFF
--- a/vignettes/pavo.Rmd
+++ b/vignettes/pavo.Rmd
@@ -12,13 +12,20 @@ vignette: >
   \usepackage[utf8]{inputenc}
 ---
 
-```{r echo=FALSE}
-knitr::opts_chunk$set(fig.align='center') 
-```
 
 <style>
+<!-- Put all captions in italics -->
 .caption {
   font-style: italic;
+}
+<!-- Center all figures. This is actually better than using knitr::opts_chunk 
+because the code is only written once in the output -->
+.figure {
+  text-align: center;
+}
+<!-- Auto-wrap long code line -->
+code.sourceCode {
+  white-space: pre-wrap;
 }
 </style>
 


### PR DESCRIPTION
Let me know if it does indeed fix the horizontal scrolling issue.

I also set the fig position via CSS instead of the knitr dedicated function because I noticed that knitr will use inline CSS for every single figure. This should reduce the file size by a couple ko (meaning it will actually probably be barely noticeable given the global file size).