### PR TITLE
New peakshape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ custom spectra labels in stacked plots.
 * Reference images in `classify()` can now be specified using either a numeric vector (to identify by image position in a list) or character vector (to identify by image name).  
 * numerous under-the-hood changes for stability and speed, with thanks to 
 three reviewers and an associate editor at MEE.
+* `peakshape()` uses a completely different algorithm to find the FWHM. It now
+works as expected for spectra with multiple peaks. See PR #137 for a detailed 
+overview of the changes.
 
 # pavo 2.0.0
 

--- a/R/peakshape.R
+++ b/R/peakshape.R
@@ -81,14 +81,10 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
   rspecdata2 <- rspecdata[wl>=lim[1] & wl<=lim[2], , drop = FALSE]
 
   Bmax <- apply(rspecdata2, 2, max) # max refls
+  Bmin <- apply(rspecdata2, 2, min) # min refls
+  Bmin_all <- apply(rspecdata, 2, min) # min refls, whole spectrum
 
-  if (absolute.min) {
-    Bmin <- apply(rspecdata, 2, min) # min refls, whole spectrum
-  } else {
-    Bmin <- apply(rspecdata2, 2, min) # min refls
-  }
-
-  halfmax <- (Bmax + Bmin) / 2 # reflectance midpoint
+  halfmax <- ifelse(absolute.min, (Bmax + Bmin_all)/2, (Bmax + Bmin)/2)
 
   Xi <- vapply(
     seq_along(rspecdata2),
@@ -115,7 +111,7 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
     return(c(fstHM, sndHM))
   })
 
-  if (any(Yj > Yk)) {
+  if (any(Bmin > Bmin_all)) {
     warning("Consider fixing ", dQuote("lim"), " in spectra with ",
             Quote("incl.min"), " marked ", dQuote("No"),
             " to incorporate all minima in spectral curves",
@@ -146,6 +142,7 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
 
   data.frame(
     id = nms[select], B3 = as.numeric(Bmax), H1 = hue,
-    FWHM = Xb - Xa, HWHM.l = hue - Xa, HWHM.r = Xb - hue
+    FWHM = Xb - Xa, HWHM.l = hue - Xa, HWHM.r = Xb - hue,
+    incl.min = c("Yes", "No")[as.numeric(Bmin > Bmin_all) + 1]
   )
 }

--- a/R/peakshape.R
+++ b/R/peakshape.R
@@ -84,7 +84,11 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
   Bmin <- apply(rspecdata2, 2, min) # min refls
   Bmin_all <- apply(rspecdata, 2, min) # min refls, whole spectrum
 
-  halfmax <- ifelse(absolute.min, (Bmax + Bmin_all)/2, (Bmax + Bmin)/2)
+  if (absolute.min) {
+    halfmax <- (Bmax + Bmin_all)/2
+  } else {
+    halfmax <- (Bmax + Bmin)/2
+  }
 
   Xi <- vapply(
     seq_along(rspecdata2),
@@ -107,7 +111,7 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
   FWHM_lims <- sapply(seq_len(ncol(rspecdata2)), function(x) {
     # Start at H1 and find first value below halfmax
     fstHM <- match(FALSE, hilo[seq(Xi[x], 1, -1), x])
-    sndHM <- match(FALSE, hilo[Xi[x]:nrow(rspecdata), x])
+    sndHM <- match(FALSE, hilo[Xi[x]:nrow(rspecdata2), x])
     return(c(fstHM, sndHM))
   })
 

--- a/R/peakshape.R
+++ b/R/peakshape.R
@@ -80,19 +80,19 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
 
   rspecdata2 <- rspecdata[wl>=lim[1] & wl<=lim[2], , drop = FALSE]
 
-  Yi <- apply(rspecdata2, 2, max) # max refls
+  Bmax <- apply(rspecdata2, 2, max) # max refls
 
   if (absolute.min) {
-    Yj <- apply(rspecdata, 2, min) # min refls, whole spectrum
+    Bmin <- apply(rspecdata, 2, min) # min refls, whole spectrum
   } else {
-    Yj <- apply(rspecdata2, 2, min) # min refls
+    Bmin <- apply(rspecdata2, 2, min) # min refls
   }
 
-  halfmax <- (Yi + Yj) / 2 # reflectance midpoint
+  halfmax <- (Bmax + Bmin) / 2 # reflectance midpoint
 
   Xi <- vapply(
     seq_along(rspecdata2),
-    function(x) which(rspecdata2[, x] == Yi[x]),
+    function(x) which(rspecdata2[, x] == Bmax[x]),
     numeric(1)
   ) # lambda_max index
   dblpeaks <- vapply(Xi, length, numeric(1))
@@ -145,7 +145,7 @@ peakshape <- function(rspecdata, select = NULL, lim = NULL,
   }
 
   data.frame(
-    id = nms[select], B3 = as.numeric(Yi), H1 = hue,
+    id = nms[select], B3 = as.numeric(Bmax), H1 = hue,
     FWHM = Xb - Xa, HWHM.l = hue - Xa, HWHM.r = Xb - hue
   )
 }


### PR DESCRIPTION
This PR proposes a completely different algorithm to find the FWHM. 

* The old algorithm estimated the FWHM by finding the closest values to the half maximum value. This meant that it could easily make mistakes when spectra had multiple peaks (see plots below).

  The new algorithm starts from the maximum value and then moves left (then right) until it finds the first value that falls below the half maximum value. This means it will never be fooled by multiple peaks

![rplot03](https://user-images.githubusercontent.com/10783929/49340184-a1edff80-f63c-11e8-86c0-21ac66dbb729.png)
*(left plot is the old algorithm and right plot is the new one)*

* With the old algorithm, it was very had to determine when the FWHM overlapped with the wavelength range. This means that the right-hand side value (`HWHM.r`) was not actually at half maximum but was the lowest value to the right of the FWHM. 

  With the new algorithm, it's trivial to detect such cases and `peakshape()` now accordingly returns `NA` when the FWHM range overlaps with the wavelength range.

![rplot02](https://user-images.githubusercontent.com/10783929/49340216-1c1e8400-f63d-11e8-8c92-0d9b9cc9ca76.png)
*(left plot is the old algorithm and right plot is the new one)*

```r
peakshape(sicalis, select = grepl("T$", colnames(sicalis)))
```
|id     |       B3|  H1| FWHM| HWHM.l| HWHM.r|
|:------|--------:|---:|----:|------:|------:|
|ind1.T | 18.38233| 653|   NA|    145|     NA|
|ind2.T | 17.66600| 681|   NA|    180|     NA|
|ind3.T | 14.53060| 671|   NA|    165|     NA|
|ind4.T | 15.12063| 660|   NA|    151|     NA|
|ind5.T | 17.49428| 627|   NA|    123|     NA|
|ind6.T | 18.02172| 632|   NA|    129|     NA|
|ind7.T | 16.76935| 672|   NA|    164|     NA|

* ~~The new algorithm is slower (spends 150% of the time spent before) than the old one but I may still be able to improve it a bit~~ (fixed by ffeb760)

|expr                                           |      min|       lq|     mean|   median|       uq|       max| neval|cld |
|:----------------------------------------------|--------:|--------:|--------:|--------:|--------:|---------:|-----:|:---|
|{     pavo::peakshape(sicalis, plot = FALSE) } | 4.736414| 4.813911| 5.634903| 4.873461| 5.059997| 186.11863|  1000|a   |
|{     peakshape(sicalis, plot = FALSE) }       | 4.697731| 4.775466| 5.324652| 4.831968| 4.966489|  15.28568|  1000|a   |
