### PR TITLE
Use cividis color palette 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ addons:
   apt:
     packages:
     - libgmp3-dev
-r_build_args:
-r_check_args:
-r_packages: rmarkdown
+r_packages: covr
 after_success:
   - Rscript -e 'goodpractice::gp(checks = c("lintr_assignment_linter", "truefalse_not_tf", "rcmdcheck_partial_argument_match"))'
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,19 +35,18 @@ Imports:
     readbitmap,
     rcdd,
     sp,
-    stats,
-    utils
+    viridisLite
 Suggests:
-    covr,
+    digest,
     imager,
     knitr,
     mapproj,
     rgl,
+    rmarkdown,
     spelling,
     testthat,
     NbClust,
-    xml2,
-    digest
+    xml2
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 Language: en-GB

--- a/R/explorespec.R
+++ b/R/explorespec.R
@@ -19,7 +19,7 @@
 #' @note Number of plots presented per page depends on the number of graphs produced.
 #'
 #' @export
-#' 
+#'
 #' @importFrom grDevices n2mfrow
 #'
 #' @examples
@@ -43,10 +43,6 @@ explorespec <- function(rspecdata, by = NULL,
 
   scale <- match.arg(scale)
 
-  ## begin CE edit
-
-  by0 <- by
-
   # default by value
   if (is.null(by)) {
     by <- 1
@@ -60,7 +56,6 @@ explorespec <- function(rspecdata, by = NULL,
   # Allow for means of every "by" data, if "by" is a single number
   # i.e. if by=3, average every 3 consecutive data of "data"
   if (length(by) == 1) {
-    nms <- names(rspecdata)[seq(1, length(names(rspecdata)), by = by)]
     by <- rep(seq_len(length(rspecdata) / by), each = by)
   }
   # check: does data have the same number of columns as the by vector?
@@ -76,14 +71,8 @@ explorespec <- function(rspecdata, by = NULL,
 
   by <- factor(by)
 
-  # return(by)
-
   # number of 'by' groups
-  numby <- length(levels(by))
-  if (numby <= 0) stop("Invalid by value") # is this needed anymore?
-  nplots <- numby
-
-  ##### end CE edit
+  numby <- nlevels(by)
 
   # setup multi-panel plot parameters
   if (numby <= 4) {
@@ -102,8 +91,8 @@ explorespec <- function(rspecdata, by = NULL,
     yaxismult <- c(0.9, 1.8)
   }
 
-  if (nplots <= 16) {
-    par(mfrow = n2mfrow(nplots))
+  if (numby <= 16) {
+    par(mfrow = n2mfrow(numby))
   }
   else {
     par(ask = TRUE)
@@ -122,7 +111,7 @@ explorespec <- function(rspecdata, by = NULL,
 
   par(mar = c(2, 2, 1, 1), oma = c(3, 3, 0, 0))
 
-  if (all(is.null(arg$ylim), scale == "equal")) {
+  if (is.null(arg$ylim) && scale == "equal") {
     arg$ylim <- c(min(rspecdata), max(rspecdata)) * yaxismult
   }
 
@@ -132,7 +121,7 @@ explorespec <- function(rspecdata, by = NULL,
   }
 
   # Do the plotting
-  for (i in seq_len(nplots)) {
+  for (i in seq_len(numby)) {
     if (numby == 1) {
       bloc <- data.frame(rspecdata[i])
     } else {

--- a/R/explorespec.R
+++ b/R/explorespec.R
@@ -115,10 +115,7 @@ explorespec <- function(rspecdata, by = NULL,
   arg$x <- wl
 
   if (is.null(arg$col)) {
-    col_list <- c(
-      "#E41A1C", "#377EB8", "#4DAF4A", "#984EA3",
-      "#FF7F00", "#FFFF33", "#A65628", "#F781BF"
-    )
+    col_list <- viridisLite::viridis(max(table(by)))
   } else {
     col_list <- arg$col
   }

--- a/R/plot.rspec.R
+++ b/R/plot.rspec.R
@@ -93,13 +93,8 @@ plot.rspec <- function(x, select = NULL, type = c("overlay", "stack", "heatmap")
     if (is.null(arg$ylim)) {
       arg$ylim <- range(varying, na.rm = TRUE)
     }
-    if (is.null(arg$col) == 1) {
-      jc <- colorRampPalette(rev(c(
-        "#9E0142", "#D53E4F", "#F46D43", "#FDAE61",
-        "#FEE08B", "#FFFFBF", "#E6F598", "#ABDDA4",
-        "#66C2A5", "#3288BD", "#5E4FA2"
-      )))
-      arg$col <- jc(n)
+    if (is.null(arg$col)) {
+      arg$col <- viridisLite::cividis(n)
     } else {
       jc <- colorRampPalette(arg$col)
       arg$col <- jc(n)


### PR DESCRIPTION
I updated the colour palettes to use viridis/cividis where possible, as recommended in the MEE review. Please let me know if I forgot any places where that change could be made as well.

I also cleaned up the dependency list:
- `rmarkdown` must be added in suggests because we use it to build the vignette
- `stats` and `utils` belong to r-base so they don't need to be listed in the dependencies
- `covr is only used for development on github so it doesn't need to be listed in the description

This adds a new dependency but I believe it's fine. `viridisLite` is really tiny and doesn't depend on any other packages. Additionally, many packages (including some very popular ones such as `ggplot2`) import it as well so it is very likely to be already installed for most users.