### PR TITLE
Roxygen7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,4 @@ VignetteBuilder:
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0

--- a/R/as.rimg.R
+++ b/R/as.rimg.R
@@ -187,7 +187,6 @@ is.rimg <- function(object) {
 #' contains a suite of useful image-processing capabilities.
 #'
 #' @param image an object of class `rimg`
-#' @inheritParams as.rimg
 #'
 #' @return an image of the specified class
 #'

--- a/man/adjacent.Rd
+++ b/man/adjacent.Rd
@@ -4,9 +4,17 @@
 \alias{adjacent}
 \title{Run an adjacency and boundary strength analysis}
 \usage{
-adjacent(classimg, xpts = NULL, xscale = NULL, bkgID = NULL,
-  polygon = NULL, exclude = c("none", "background", "object"),
-  coldists = NULL, hsl = NULL, cores = getOption("mc.cores", 2L))
+adjacent(
+  classimg,
+  xpts = NULL,
+  xscale = NULL,
+  bkgID = NULL,
+  polygon = NULL,
+  exclude = c("none", "background", "object"),
+  coldists = NULL,
+  hsl = NULL,
+  cores = getOption("mc.cores", 2L)
+)
 }
 \arguments{
 \item{classimg}{(required) an xyz matrix, or list of matrices, in which
@@ -93,15 +101,15 @@ transitions entirely within the focal object and those involving the object and 
 \code{Rt = St_a_a / St_a_b}.
 \item \code{'Rab'}: Ratio of animal-animal and background-background transition diversities,
 \code{Rt = St_a_a / St_b_b}.
-\item \code{'m_dS', 's_dS', 'cv_dS'}: weighted mean, sd, and coefficient of
+\item \verb{'m_dS', 's_dS', 'cv_dS'}: weighted mean, sd, and coefficient of
 variation of the chromatic boundary strength.
-\item \code{'m_dL', 's_dL', 'cv_dL'}: weighted mean, sd, and coefficient of
+\item \verb{'m_dL', 's_dL', 'cv_dL'}: weighted mean, sd, and coefficient of
 variation of the achromatic boundary strength.
-\item \code{'m_hue', 's_hue', 'var_hue'}: circular mean, sd, and variance of
+\item \verb{'m_hue', 's_hue', 'var_hue'}: circular mean, sd, and variance of
 overall pattern hue (in radians).
-\item \code{'m_sat', 's_sat', 'cv_sat'}: weighted mean, sd, and coefficient
+\item \verb{'m_sat', 's_sat', 'cv_sat'}: weighted mean, sd, and coefficient
 variation of overall pattern saturation.
-\item \code{'m_lum', 's_lum', 'cv_lum'}: weighted mean, sd, and coefficient
+\item \verb{'m_lum', 's_lum', 'cv_lum'}: weighted mean, sd, and coefficient
 variation of overall pattern luminance.
 }
 }

--- a/man/aggplot.Rd
+++ b/man/aggplot.Rd
@@ -4,8 +4,17 @@
 \alias{aggplot}
 \title{Plot aggregated reflectance spectra}
 \usage{
-aggplot(rspecdata, by = NULL, FUN.center = mean, FUN.error = sd,
-  lcol = NULL, shadecol = NULL, alpha = 0.2, legend = FALSE, ...)
+aggplot(
+  rspecdata,
+  by = NULL,
+  FUN.center = mean,
+  FUN.error = sd,
+  lcol = NULL,
+  shadecol = NULL,
+  alpha = 0.2,
+  legend = FALSE,
+  ...
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/as.rspec.Rd
+++ b/man/as.rspec.Rd
@@ -5,8 +5,13 @@
 \alias{is.rspec}
 \title{Convert data to an rspec object}
 \usage{
-as.rspec(object, whichwl = NULL, interp = TRUE, lim = NULL,
-  exceed.range = TRUE)
+as.rspec(
+  object,
+  whichwl = NULL,
+  interp = TRUE,
+  lim = NULL,
+  exceed.range = TRUE
+)
 
 is.rspec(object)
 }

--- a/man/axistetra.Rd
+++ b/man/axistetra.Rd
@@ -4,10 +4,19 @@
 \alias{axistetra}
 \title{Plot reference axes in a static tetrahedral colourspace}
 \usage{
-axistetra(x = 0, y = 1.3, size = 0.1, arrowhead = 0.05,
-  col = par("fg"), lty = par("lty"), lwd = par("lwd"),
-  label = TRUE, adj.label = list(x = c(0.003, 0), y = c(0.003, 0.003),
-  z = c(0, 0.003)), label.cex = 1, label.col = NULL)
+axistetra(
+  x = 0,
+  y = 1.3,
+  size = 0.1,
+  arrowhead = 0.05,
+  col = par("fg"),
+  lty = par("lty"),
+  lwd = par("lwd"),
+  label = TRUE,
+  adj.label = list(x = c(0.003, 0), y = c(0.003, 0.003), z = c(0, 0.003)),
+  label.cex = 1,
+  label.col = NULL
+)
 }
 \arguments{
 \item{x, y}{position of the legend relative to plot limits

--- a/man/bootcoldist.Rd
+++ b/man/bootcoldist.Rd
@@ -4,8 +4,14 @@
 \alias{bootcoldist}
 \title{Bootstrap colour distance confidence intervals}
 \usage{
-bootcoldist(vismodeldata, by, boot.n = 1000, alpha = 0.95,
-  cores = getOption("mc.cores", 2L), ...)
+bootcoldist(
+  vismodeldata,
+  by,
+  boot.n = 1000,
+  alpha = 0.95,
+  cores = getOption("mc.cores", 2L),
+  ...
+)
 }
 \arguments{
 \item{vismodeldata}{(required) quantum catch colour data.

--- a/man/categorical.Rd
+++ b/man/categorical.Rd
@@ -14,11 +14,11 @@ with four columns named 'u' ,'s', 'm', 'l', representing a tetrachromatic dipter
 \value{
 Object of class \code{colspace} consisting of the following columns:
 \itemize{
-\item \code{R7p, R7y, R8p, R8y}: the quantum catch data used to
+\item \verb{R7p, R7y, R8p, R8y}: the quantum catch data used to
 calculate the remaining variables.
-\item \code{x, y}: cartesian coordinates in the categorical colour space.
+\item \verb{x, y}: cartesian coordinates in the categorical colour space.
 \item \code{r.vec}: the r vector (saturation, distance from the center).
-\item \code{category}: fly-colour category. One of \code{p-y-}, \code{p-y+}, \code{p+y-}, \code{p+y+}.
+\item \code{category}: fly-colour category. One of \verb{p-y-}, \verb{p-y+}, \verb{p+y-}, \verb{p+y+}.
 }
 }
 \description{

--- a/man/cie.Rd
+++ b/man/cie.Rd
@@ -16,12 +16,12 @@ data frame with three columns representing trichromatic viewer).}
 \value{
 Object of class \code{\link{colspace}} containing:
 \itemize{
-\item \code{X, Y, Z}: Tristimulus values.
-\item \code{x, y, z}: Cartesian coordinates, when using \code{space = XYZ}.
-\item \code{L, a, b}: Lightness, \code{L}, and colour-opponent \code{a} (redness-greenness) and
+\item \verb{X, Y, Z}: Tristimulus values.
+\item \verb{x, y, z}: Cartesian coordinates, when using \code{space = XYZ}.
+\item \verb{L, a, b}: Lightness, \code{L}, and colour-opponent \code{a} (redness-greenness) and
 \code{b} (yellowness-blueness) values, in a Cartesian coordinate space. Returned
 when using \code{space = LAB}.
-\item \code{L, a, b, C, h}: Lightness, \code{L}, colour-opponent \code{a} (redness-greenness)
+\item \verb{L, a, b, C, h}: Lightness, \code{L}, colour-opponent \code{a} (redness-greenness)
 and \code{b} (yellowness-blueness) values, as well as chroma \code{C} and hue-angle \code{h}
 (degrees), the latter of which are cylindrical representations of \code{a} and \code{b}
 from the CIELAB model. Returned when using \code{space = LCh}.

--- a/man/cieplot.Rd
+++ b/man/cieplot.Rd
@@ -4,9 +4,21 @@
 \alias{cieplot}
 \title{CIE plot}
 \usage{
-cieplot(ciedata, mono = TRUE, out.lwd = NULL, out.lcol = "black",
-  out.lty = 1, theta = 45, phi = 10, r = 1e+06, zoom = 1,
-  box = FALSE, margin = c(0, 0, 0, 0), ciebg = TRUE, ...)
+cieplot(
+  ciedata,
+  mono = TRUE,
+  out.lwd = NULL,
+  out.lcol = "black",
+  out.lty = 1,
+  theta = 45,
+  phi = 10,
+  r = 1e+06,
+  zoom = 1,
+  box = FALSE,
+  margin = c(0, 0, 0, 0),
+  ciebg = TRUE,
+  ...
+)
 }
 \arguments{
 \item{ciedata}{(required). a data frame, possibly a result from the \code{\link[=colspace]{colspace()}}

--- a/man/classify.Rd
+++ b/man/classify.Rd
@@ -4,9 +4,17 @@
 \alias{classify}
 \title{Identify colour classes in an image for adjacency analyses}
 \usage{
-classify(imgdat, method = c("kMeans", "kMedoids"), kcols = NULL,
-  refID = NULL, interactive = FALSE, plotnew = FALSE, col = "red",
-  cores = getOption("mc.cores", 2L), ...)
+classify(
+  imgdat,
+  method = c("kMeans", "kMedoids"),
+  kcols = NULL,
+  refID = NULL,
+  interactive = FALSE,
+  plotnew = FALSE,
+  col = "red",
+  cores = getOption("mc.cores", 2L),
+  ...
+)
 }
 \arguments{
 \item{imgdat}{(required) image data. Either a single image, or a series of images

--- a/man/cocplot.Rd
+++ b/man/cocplot.Rd
@@ -4,9 +4,18 @@
 \alias{cocplot}
 \title{Plot the colour opponent coding diagram}
 \usage{
-cocplot(cocdata, labels = TRUE, labels.cex = 0.9, tick.loc = c(-12,
-  -9, -6, -3, 3, 6, 9, 12), achro = FALSE, achrosize = 0.8,
-  achrocol = "grey", margins = c(1, 1, 2, 2), square = TRUE, ...)
+cocplot(
+  cocdata,
+  labels = TRUE,
+  labels.cex = 0.9,
+  tick.loc = c(-12, -9, -6, -3, 3, 6, 9, 12),
+  achro = FALSE,
+  achrosize = 0.8,
+  achrocol = "grey",
+  margins = c(1, 1, 2, 2),
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{cocdata}{(required) a data frame, possibly a result from the

--- a/man/coldist.Rd
+++ b/man/coldist.Rd
@@ -4,9 +4,17 @@
 \alias{coldist}
 \title{Colour distances}
 \usage{
-coldist(modeldata, noise = c("neural", "quantum"), subset = NULL,
-  achromatic = FALSE, qcatch = NULL, n = c(1, 2, 2, 4),
-  weber = 0.1, weber.ref = "longest", weber.achro = 0.1)
+coldist(
+  modeldata,
+  noise = c("neural", "quantum"),
+  subset = NULL,
+  achromatic = FALSE,
+  qcatch = NULL,
+  n = c(1, 2, 2, 4),
+  weber = 0.1,
+  weber.ref = "longest",
+  weber.achro = 0.1
+)
 }
 \arguments{
 \item{modeldata}{(required) quantum catch colour data. Can be the result from
@@ -73,7 +81,7 @@ objects.}
 }
 \value{
 A data frame containing up to 4 columns. The first two
-(\code{patch1, patch2}) refer to the two colors being contrasted; \code{dS} is the
+(\verb{patch1, patch2}) refer to the two colors being contrasted; \code{dS} is the
 chromatic contrast (delta S) and \code{dL} is the achromatic contrast (delta L).
 Units of \code{dS} JND's in the receptor-noise model, unweighted Euclidean
 distances in colorspace models, and Manhattan distances in the

--- a/man/colspace.Rd
+++ b/man/colspace.Rd
@@ -4,9 +4,12 @@
 \alias{colspace}
 \title{Model spectra in a colorspace}
 \usage{
-colspace(vismodeldata, space = c("auto", "di", "tri", "tcs", "hexagon",
-  "coc", "categorical", "ciexyz", "cielab", "cielch", "segment"),
-  qcatch = NULL)
+colspace(
+  vismodeldata,
+  space = c("auto", "di", "tri", "tcs", "hexagon", "coc", "categorical", "ciexyz",
+    "cielab", "cielch", "segment"),
+  qcatch = NULL
+)
 }
 \arguments{
 \item{vismodeldata}{(required) quantum catch color data. Can be either the

--- a/man/diplot.Rd
+++ b/man/diplot.Rd
@@ -4,9 +4,20 @@
 \alias{diplot}
 \title{Plot a dichromat segment}
 \usage{
-diplot(didata, labels = TRUE, achro = TRUE, achrocol = "grey",
-  achrosize = 0.8, labels.cex = 1, out.lwd = 1, out.lcol = "black",
-  out.lty = 1, margins = c(1, 1, 2, 2), square = TRUE, ...)
+diplot(
+  didata,
+  labels = TRUE,
+  achro = TRUE,
+  achrocol = "grey",
+  achrosize = 0.8,
+  labels.cex = 1,
+  out.lwd = 1,
+  out.lcol = "black",
+  out.lty = 1,
+  margins = c(1, 1, 2, 2),
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{didata}{(required) a data frame, possibly a result from the

--- a/man/explorespec.Rd
+++ b/man/explorespec.Rd
@@ -4,8 +4,13 @@
 \alias{explorespec}
 \title{Plot spectral curves}
 \usage{
-explorespec(rspecdata, by = NULL, scale = c("equal", "free"),
-  legpos = "topright", ...)
+explorespec(
+  rspecdata,
+  by = NULL,
+  scale = c("equal", "free"),
+  legpos = "topright",
+  ...
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/getimg.Rd
+++ b/man/getimg.Rd
@@ -4,8 +4,13 @@
 \alias{getimg}
 \title{Import image data}
 \usage{
-getimg(imgpath = getwd(), subdir = FALSE, subdir.names = FALSE,
-  max.size = 1, cores)
+getimg(
+  imgpath = getwd(),
+  subdir = FALSE,
+  subdir.names = FALSE,
+  max.size = 1,
+  cores
+)
 }
 \arguments{
 \item{imgpath}{(required) either the full file-path or URL to an image (including extension),

--- a/man/getspec.Rd
+++ b/man/getspec.Rd
@@ -4,9 +4,17 @@
 \alias{getspec}
 \title{Import spectra files}
 \usage{
-getspec(where = getwd(), ext = "txt", lim = c(300, 700),
-  decimal = ".", sep = NULL, subdir = FALSE, subdir.names = FALSE,
-  cores = getOption("mc.cores", 2L), ignore.case = TRUE)
+getspec(
+  where = getwd(),
+  ext = "txt",
+  lim = c(300, 700),
+  decimal = ".",
+  sep = NULL,
+  subdir = FALSE,
+  subdir.names = FALSE,
+  cores = getOption("mc.cores", 2L),
+  ignore.case = TRUE
+)
 }
 \arguments{
 \item{where}{(required) folder in which files are located.}

--- a/man/hexplot.Rd
+++ b/man/hexplot.Rd
@@ -4,10 +4,22 @@
 \alias{hexplot}
 \title{Plot a colour hexagon}
 \usage{
-hexplot(hexdata, achro = TRUE, labels = TRUE, sectors = c("none",
-  "fine", "coarse"), sec.col = "grey", out.lwd = 1, out.lty = 1,
-  out.lcol = "black", labels.cex = 1, achrosize = 0.8,
-  achrocol = "grey", margins = c(1, 1, 2, 2), square = TRUE, ...)
+hexplot(
+  hexdata,
+  achro = TRUE,
+  labels = TRUE,
+  sectors = c("none", "fine", "coarse"),
+  sec.col = "grey",
+  out.lwd = 1,
+  out.lty = 1,
+  out.lcol = "black",
+  labels.cex = 1,
+  achrosize = 0.8,
+  achrocol = "grey",
+  margins = c(1, 1, 2, 2),
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{hexdata}{(required) a data frame, possibly a result from the

--- a/man/jnd2xyz.Rd
+++ b/man/jnd2xyz.Rd
@@ -4,9 +4,16 @@
 \alias{jnd2xyz}
 \title{Convert JND distances into perceptually-corrected Cartesian coordinates}
 \usage{
-jnd2xyz(coldistres, center = TRUE, rotate = TRUE,
-  rotcenter = c("mean", "achro"), ref1 = "l", ref2 = "u",
-  axis1 = c(1, 1, 0), axis2 = c(0, 0, 1))
+jnd2xyz(
+  coldistres,
+  center = TRUE,
+  rotate = TRUE,
+  rotcenter = c("mean", "achro"),
+  ref1 = "l",
+  ref2 = "u",
+  axis1 = c(1, 1, 0),
+  axis2 = c(0, 0, 1)
+)
 }
 \arguments{
 \item{coldistres}{(required) the output from a \code{\link[=coldist]{coldist()}} call.}

--- a/man/jndplot.Rd
+++ b/man/jndplot.Rd
@@ -4,9 +4,18 @@
 \alias{jndplot}
 \title{Perceptually-corrected chromaticity diagrams}
 \usage{
-jndplot(x, arrow = c("relative", "absolute", "none"), achro = FALSE,
-  arrow.labels = TRUE, arrow.col = "darkgrey", arrow.p = 1,
-  labels.cex = 1, margin = "recommended", square = TRUE, ...)
+jndplot(
+  x,
+  arrow = c("relative", "absolute", "none"),
+  achro = FALSE,
+  arrow.labels = TRUE,
+  arrow.col = "darkgrey",
+  arrow.p = 1,
+  labels.cex = 1,
+  margin = "recommended",
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{(required) the output from a \code{\link[=jnd2xyz]{jnd2xyz()}} call.}
@@ -54,7 +63,7 @@ scaled with the \code{arrow.p} argument.
 \item \code{"absolute"}: With this option, arrows will be made to reflect the visual
 system underlying the data. Arrows will be centered on the achromatic point
 in colourspace, and will have length equal to the distance to a
-monochromatic point (i.e. a colour that stimulates approximately 99.9% of
+monochromatic point (i.e. a colour that stimulates approximately 99.9\% of
 that receptor alone). Arrows can still be scaled using the \code{arrow.p}
 argument, in which case they cannot be interpreted as described.
 \item \code{"none"}: no arrows will be included.

--- a/man/jndrot.Rd
+++ b/man/jndrot.Rd
@@ -4,8 +4,14 @@
 \alias{jndrot}
 \title{Rotate Cartesian coordinates obtained from \code{\link[=jnd2xyz]{jnd2xyz()}}}
 \usage{
-jndrot(jnd2xyzres, center = c("mean", "achro"), ref1 = "l",
-  ref2 = "u", axis1 = c(1, 1, 0), axis2 = c(0, 0, 1))
+jndrot(
+  jnd2xyzres,
+  center = c("mean", "achro"),
+  ref1 = "l",
+  ref2 = "u",
+  axis1 = c(1, 1, 0),
+  axis2 = c(0, 0, 1)
+)
 }
 \arguments{
 \item{jnd2xyzres}{(required) the output from a \code{\link[=jnd2xyz]{jnd2xyz()}} call.}

--- a/man/pavo-package.Rd
+++ b/man/pavo-package.Rd
@@ -20,15 +20,15 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Rafael Maia \email{rm72@zips.uakron.edu} (0000-0002-7563-9795)
+\strong{Maintainer}: Rafael Maia \email{rm72@zips.uakron.edu} (\href{https://orcid.org/0000-0002-7563-9795}{ORCID})
 
 Authors:
 \itemize{
-  \item Thomas White \email{thomas.white026@gmail.com} (0000-0002-3976-1734)
-  \item Hugo Gruson \email{hugo.gruson+R@normalesup.org} (0000-0002-4094-1476)
+  \item Thomas White \email{thomas.white026@gmail.com} (\href{https://orcid.org/0000-0002-3976-1734}{ORCID})
+  \item Hugo Gruson \email{hugo.gruson+R@normalesup.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID})
   \item John Endler \email{john.endler@deakin.edu.au}
   \item Chad Eliason \email{cme16@zips.uakron.edu}
-  \item Pierre-Paul Bitton \email{bittonp@uwindsor.ca} (0000-0001-5984-2331)
+  \item Pierre-Paul Bitton \email{bittonp@uwindsor.ca} (\href{https://orcid.org/0000-0001-5984-2331}{ORCID})
 }
 
 }

--- a/man/peakshape.Rd
+++ b/man/peakshape.Rd
@@ -4,8 +4,15 @@
 \alias{peakshape}
 \title{Peak shape descriptors}
 \usage{
-peakshape(rspecdata, select = NULL, lim = NULL, plot = TRUE,
-  ask = FALSE, absolute.min = FALSE, ...)
+peakshape(
+  rspecdata,
+  select = NULL,
+  lim = NULL,
+  plot = TRUE,
+  ask = FALSE,
+  absolute.min = FALSE,
+  ...
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/plot.rspec.Rd
+++ b/man/plot.rspec.Rd
@@ -4,8 +4,15 @@
 \alias{plot.rspec}
 \title{Plot spectra}
 \usage{
-\method{plot}{rspec}(x, select = NULL, type = c("overlay", "stack",
-  "heatmap"), varying = NULL, n = 100, labels.stack = NULL, ...)
+\method{plot}{rspec}(
+  x,
+  select = NULL,
+  type = c("overlay", "stack", "heatmap"),
+  varying = NULL,
+  n = 100,
+  labels.stack = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{(required) a data frame, possibly an object of class \code{rspec},

--- a/man/plotsmooth.Rd
+++ b/man/plotsmooth.Rd
@@ -4,8 +4,14 @@
 \alias{plotsmooth}
 \title{Plot loess smoothed curves}
 \usage{
-plotsmooth(rspecdata, minsmooth = 0.05, maxsmooth = 0.2, curves = 5,
-  specnum = 0, ask = TRUE)
+plotsmooth(
+  rspecdata,
+  minsmooth = 0.05,
+  maxsmooth = 0.2,
+  curves = 5,
+  specnum = 0,
+  ask = TRUE
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/procimg.Rd
+++ b/man/procimg.Rd
@@ -4,9 +4,19 @@
 \alias{procimg}
 \title{Process images}
 \usage{
-procimg(image, resize = NULL, rotate = NULL, scaledist = NULL,
-  outline = FALSE, reclass = NULL, smooth = FALSE, iterations = 1L,
-  col = "red", plotnew = FALSE, ...)
+procimg(
+  image,
+  resize = NULL,
+  rotate = NULL,
+  scaledist = NULL,
+  outline = FALSE,
+  reclass = NULL,
+  smooth = FALSE,
+  iterations = 1L,
+  col = "red",
+  plotnew = FALSE,
+  ...
+)
 }
 \arguments{
 \item{image}{(required) image data. Either a single image array, or a number of images

--- a/man/procspec.Rd
+++ b/man/procspec.Rd
@@ -4,9 +4,13 @@
 \alias{procspec}
 \title{Process spectra}
 \usage{
-procspec(rspecdata, opt = c("none", "smooth", "maximum", "minimum",
-  "bin", "sum", "center"), fixneg = c("none", "addmin", "zero"),
-  span = 0.25, bins = 20)
+procspec(
+  rspecdata,
+  opt = c("none", "smooth", "maximum", "minimum", "bin", "sum", "center"),
+  fixneg = c("none", "addmin", "zero"),
+  span = 0.25,
+  bins = 20
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/segplot.Rd
+++ b/man/segplot.Rd
@@ -4,9 +4,18 @@
 \alias{segplot}
 \title{Plot the segment-analysis model}
 \usage{
-segplot(segdata, labels = TRUE, lab.cex = 0.9, out.lwd = 1,
-  out.lty = 1, out.lcol = "black", tick.loc = c(-1, -0.5, 0.5, 1),
-  margins = c(1, 1, 2, 2), square = TRUE, ...)
+segplot(
+  segdata,
+  labels = TRUE,
+  lab.cex = 0.9,
+  out.lwd = 1,
+  out.lty = 1,
+  out.lcol = "black",
+  tick.loc = c(-1, -0.5, 0.5, 1),
+  margins = c(1, 1, 2, 2),
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{segdata}{(required) a data frame, possibly a result from the

--- a/man/sensdata.Rd
+++ b/man/sensdata.Rd
@@ -4,13 +4,16 @@
 \alias{sensdata}
 \title{Retrieve or plot in-built spectral sensitivity data}
 \usage{
-sensdata(visual = c("none", "all", "avg.uv", "avg.v", "bluetit",
-  "ctenophorus", "star", "pfowl", "apis", "canis", "cie2", "cie10",
-  "musca", "habronattus", "rhinecanthus"), achromatic = c("none", "all",
-  "bt.dc", "ch.dc", "st.dc", "md.r1", "ra.dc", "cf.r"), illum = c("none",
-  "all", "bluesky", "D65", "forestshade"), trans = c("none", "all",
-  "bluetit", "blackbird"), bkg = c("none", "all", "green"),
-  plot = FALSE, ...)
+sensdata(
+  visual = c("none", "all", "avg.uv", "avg.v", "bluetit", "ctenophorus", "star",
+    "pfowl", "apis", "canis", "cie2", "cie10", "musca", "habronattus", "rhinecanthus"),
+  achromatic = c("none", "all", "bt.dc", "ch.dc", "st.dc", "md.r1", "ra.dc", "cf.r"),
+  illum = c("none", "all", "bluesky", "D65", "forestshade"),
+  trans = c("none", "all", "bluetit", "blackbird"),
+  bkg = c("none", "all", "green"),
+  plot = FALSE,
+  ...
+)
 }
 \arguments{
 \item{visual}{visual systems. Options are:

--- a/man/sensmodel.Rd
+++ b/man/sensmodel.Rd
@@ -4,9 +4,16 @@
 \alias{sensmodel}
 \title{Modeling spectral sensitivity}
 \usage{
-sensmodel(peaksens, range = c(300, 700), lambdacut = NULL,
-  Bmid = NULL, oiltype = NULL, beta = TRUE, om = NULL,
-  integrate = TRUE)
+sensmodel(
+  peaksens,
+  range = c(300, 700),
+  lambdacut = NULL,
+  Bmid = NULL,
+  oiltype = NULL,
+  beta = TRUE,
+  om = NULL,
+  integrate = TRUE
+)
 }
 \arguments{
 \item{peaksens}{(required) a vector with peak sensitivities for the cones to

--- a/man/summary.colspace.Rd
+++ b/man/summary.colspace.Rd
@@ -27,7 +27,7 @@ options specified when calculating the visual model. Also return the default
 \code{data.frame} summary, except when the object is the result of \code{\link[=tcspace]{tcspace()}},
 in which case the following variables are output instead:
 \itemize{
-\item \code{centroid.u, .s, .m, .l} the centroids of \code{usml} coordinates of points.
+\item \verb{centroid.u, .s, .m, .l} the centroids of \code{usml} coordinates of points.
 \item \code{c.vol} the total volume occupied by the points.
 \item \code{rel.c.vol} volume occupied by the points relative to the tetrahedron volume.
 \item \code{colspan.m} the mean hue span.

--- a/man/summary.rimg.Rd
+++ b/man/summary.rimg.Rd
@@ -4,8 +4,7 @@
 \alias{summary.rimg}
 \title{Image summary}
 \usage{
-\method{summary}{rimg}(object, plot = FALSE, axes = TRUE, col = NULL,
-  ...)
+\method{summary}{rimg}(object, plot = FALSE, axes = TRUE, col = NULL, ...)
 }
 \arguments{
 \item{object}{(required) an image of class \code{rimg}, or list thereof.}

--- a/man/summary.rspec.Rd
+++ b/man/summary.rspec.Rd
@@ -4,8 +4,7 @@
 \alias{summary.rspec}
 \title{Colourimetric variables}
 \usage{
-\method{summary}{rspec}(object, subset = FALSE, wlmin = NULL,
-  wlmax = NULL, ...)
+\method{summary}{rspec}(object, subset = FALSE, wlmin = NULL, wlmax = NULL, ...)
 }
 \arguments{
 \item{object}{(required) a data frame, possibly an object of class \code{rspec},

--- a/man/tcsplot.Rd
+++ b/man/tcsplot.Rd
@@ -6,15 +6,34 @@
 \alias{tcsvol}
 \title{Interactive plot of a tetrahedral colourspace}
 \usage{
-tcsplot(tcsdata, size = 0.02, alpha = 1, col = "black",
-  vertexsize = 0.02, achro = TRUE, achrosize = 0.01,
-  achrocol = "grey", lwd = 1, lcol = "lightgrey", new = FALSE,
-  hspin = FALSE, vspin = FALSE, floor = TRUE)
+tcsplot(
+  tcsdata,
+  size = 0.02,
+  alpha = 1,
+  col = "black",
+  vertexsize = 0.02,
+  achro = TRUE,
+  achrosize = 0.01,
+  achrocol = "grey",
+  lwd = 1,
+  lcol = "lightgrey",
+  new = FALSE,
+  hspin = FALSE,
+  vspin = FALSE,
+  floor = TRUE
+)
 
 tcspoints(tcsdata, size = 0.02, col = "black", alpha = 1)
 
-tcsvol(tcsdata, col = "black", alpha = 0.2, grid.alpha = 1,
-  grid = TRUE, fill = TRUE, lwd = 1)
+tcsvol(
+  tcsdata,
+  col = "black",
+  alpha = 0.2,
+  grid.alpha = 1,
+  grid = TRUE,
+  fill = TRUE,
+  lwd = 1
+)
 }
 \arguments{
 \item{tcsdata}{(required) a data frame, possibly a result from the

--- a/man/tetraplot.Rd
+++ b/man/tetraplot.Rd
@@ -4,12 +4,30 @@
 \alias{tetraplot}
 \title{Plot a static tetrahedral colorspace}
 \usage{
-tetraplot(tcsdata, theta = 45, phi = 10, perspective = FALSE,
-  range = c(1, 2), r = 1e+06, zoom = 1, achro = TRUE,
-  achro.col = "grey", achro.size = 1, achro.line = FALSE,
-  achro.lwd = 1, achro.lty = 3, tetrahedron = TRUE, vert.cex = 1,
-  vert.range = c(1, 2), out.lwd = 1, out.lcol = "darkgrey",
-  margin = c(0, 0, 0, 0), type = "p", labels = FALSE, ...)
+tetraplot(
+  tcsdata,
+  theta = 45,
+  phi = 10,
+  perspective = FALSE,
+  range = c(1, 2),
+  r = 1e+06,
+  zoom = 1,
+  achro = TRUE,
+  achro.col = "grey",
+  achro.size = 1,
+  achro.line = FALSE,
+  achro.lwd = 1,
+  achro.lty = 3,
+  tetrahedron = TRUE,
+  vert.cex = 1,
+  vert.range = c(1, 2),
+  out.lwd = 1,
+  out.lcol = "darkgrey",
+  margin = c(0, 0, 0, 0),
+  type = "p",
+  labels = FALSE,
+  ...
+)
 }
 \arguments{
 \item{tcsdata}{(required) a data frame, possibly a result from the

--- a/man/triplot.Rd
+++ b/man/triplot.Rd
@@ -4,9 +4,20 @@
 \alias{triplot}
 \title{Plot a Maxwell triangle}
 \usage{
-triplot(tridata, labels = TRUE, achro = TRUE, achrocol = "grey",
-  achrosize = 0.8, labels.cex = 1, out.lwd = 1, out.lcol = "black",
-  out.lty = 1, margins = c(1, 1, 2, 2), square = TRUE, ...)
+triplot(
+  tridata,
+  labels = TRUE,
+  achro = TRUE,
+  achrocol = "grey",
+  achrosize = 0.8,
+  labels.cex = 1,
+  out.lwd = 1,
+  out.lcol = "black",
+  out.lty = 1,
+  margins = c(1, 1, 2, 2),
+  square = TRUE,
+  ...
+)
 }
 \arguments{
 \item{tridata}{(required) a data frame, possibly a result from the

--- a/man/vismodel.Rd
+++ b/man/vismodel.Rd
@@ -4,14 +4,20 @@
 \alias{vismodel}
 \title{Visual models}
 \usage{
-vismodel(rspecdata, visual = c("avg.uv", "avg.v", "bluetit",
-  "ctenophorus", "star", "pfowl", "apis", "canis", "cie2", "cie10",
-  "musca", "segment", "habronattus", "rhinecanthus"),
-  achromatic = c("none", "bt.dc", "ch.dc", "st.dc", "md.r1", "ra.dc",
-  "cf.r", "ml", "l", "all"), illum = c("ideal", "bluesky", "D65",
-  "forestshade"), trans = c("ideal", "bluetit", "blackbird"),
-  qcatch = c("Qi", "fi", "Ei"), bkg = c("ideal", "green"),
-  vonkries = FALSE, scale = 1, relative = TRUE)
+vismodel(
+  rspecdata,
+  visual = c("avg.uv", "avg.v", "bluetit", "ctenophorus", "star", "pfowl", "apis",
+    "canis", "cie2", "cie10", "musca", "segment", "habronattus", "rhinecanthus"),
+  achromatic = c("none", "bt.dc", "ch.dc", "st.dc", "md.r1", "ra.dc", "cf.r", "ml", "l",
+    "all"),
+  illum = c("ideal", "bluesky", "D65", "forestshade"),
+  trans = c("ideal", "bluetit", "blackbird"),
+  qcatch = c("Qi", "fi", "Ei"),
+  bkg = c("ideal", "green"),
+  vonkries = FALSE,
+  scale = 1,
+  relative = TRUE
+)
 }
 \arguments{
 \item{rspecdata}{(required) a data frame, possibly of class \code{rspec}, which

--- a/man/vol.Rd
+++ b/man/vol.Rd
@@ -4,8 +4,7 @@
 \alias{vol}
 \title{Plot a tetrahedral colour space}
 \usage{
-vol(tcsdata, alpha = 0.2, grid = TRUE, fill = TRUE, new = FALSE,
-  ...)
+vol(tcsdata, alpha = 0.2, grid = TRUE, fill = TRUE, new = FALSE, ...)
 }
 \arguments{
 \item{tcsdata}{(required) a data frame, possibly a result from the

--- a/man/voloverlap.Rd
+++ b/man/voloverlap.Rd
@@ -4,9 +4,20 @@
 \alias{voloverlap}
 \title{Colour volume overlap}
 \usage{
-voloverlap(colsp1, colsp2, plot = FALSE, interactive = FALSE,
-  col = c("blue", "red", "darkgrey"), fill = FALSE, new = TRUE,
-  montecarlo = NULL, nsamp = NULL, psize = NULL, lwd = 1, ...)
+voloverlap(
+  colsp1,
+  colsp2,
+  plot = FALSE,
+  interactive = FALSE,
+  col = c("blue", "red", "darkgrey"),
+  fill = FALSE,
+  new = TRUE,
+  montecarlo = NULL,
+  nsamp = NULL,
+  psize = NULL,
+  lwd = 1,
+  ...
+)
 }
 \arguments{
 \item{colsp1, colsp2}{(required) data frame, possibly a result from the \code{\link[=colspace]{colspace()}}


### PR DESCRIPTION
This is submitted as a PR to discuss what we decide to do with `roxygen2` 7.0.0. [As explained in the blog post](https://www.tidyverse.org/blog/2019/11/roxygen2-7-0-0/#changes-to-rd-output), each arg now has its own line in the docs. Is it something we want? 

We can turn this behaviour off by adding `Roxygen: list(old_usage = TRUE)` to the `DESCRIPTION`.