### PR TITLE
Add note to explain why vismodel may fail

### DIFF
--- a/R/vismodel.R
+++ b/R/vismodel.R
@@ -75,6 +75,11 @@
 #'  photoreceptors considered. Information on the parameters used in the calculation are also
 #'  stored and can be called using the [summary.vismodel()] function.
 #'
+#' @note
+#' Built-in `visual`, `achromatic`, `illum`, `bkg` and `trans` are only defined
+#' on the 300 to 700nm wavelength range. If you wish to work outside this range,
+#' you will need to provide your own data.
+#'
 #' @export
 #'
 #' @examples

--- a/man/vismodel.Rd
+++ b/man/vismodel.Rd
@@ -120,6 +120,11 @@ stored and can be called using the \code{\link[=summary.vismodel]{summary.vismod
 Calculates quantum catches at each photoreceptor. Both raw and relative values
 can be returned, for use in a suite of colourspace and non-colourspace models.
 }
+\note{
+Built-in \code{visual}, \code{achromatic}, \code{illum}, \code{bkg} and \code{trans} are only defined
+on the 300 to 700nm wavelength range. If you wish to work outside this range,
+you will need to provide your own data.
+}
 \examples{
 # Dichromat (dingo)
 data(flowers)


### PR DESCRIPTION
I think this issue will become more and more common. The current `vismodel` error is:

``` r
library(pavo)
#> Welcome to pavo 2! Take a look at the latest features (and update your bibliography) in our recent publication: Maia R., Gruson H., Endler J. A., White T. E. (2019) pavo 2: new tools for the spectral and spatial analysis of colour in R. Methods in Ecology and Evolution, 10, 1097-1107.
data(flowers)

flowers_NIR <- as.rspec(flowers, lim = c(300, 1200))
#> wavelengths found in column 1
#> Warning in as.rspec(flowers, lim = c(300, 1200)): Interpolating beyond the range
#> of actual data. Check 'lim' and `exceed.range` arguments to confirm this is the
#> desired behaviour.

vismodel(flowers_NIR)
#> Error in vismodel(flowers_NIR): wavelength range in spectra and visual system data do not match
```

<sup>Created on 2020-02-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

but it doesn't pinpoint the exact source of the issue and how to solve it. This might help?