### PR TITLE
summary.rspec revamp

### DIFF
--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -11,7 +11,8 @@
 #' Andersson and Prager 2006) are returned. Finally, a user-specified string of variable
 #' names can be used in order to filter and show only those variables.
 #' @param lim vector specifying wavelength range to interpolate over (e.g.
-#'   `c(300, 700)`).
+#'   `c(300, 700)`). Defaults to the entire range in the `rspec` object. 
+#'   Replaces the deprecated `wlmin` and `wlmax` arguments.
 #' @param wlmin,wlmax (deprecated) minimum and maximum used to define the range of wavelengths used in
 #' calculations (default is to use entire range in the `rspec` object).
 #' @param ... class consistency (ignored)
@@ -21,7 +22,7 @@
 #' The colorimetric variables calculated by this function are
 #' described in Montgomerie (2006) with corrections included in the README CLR
 #' file from the May 2008 distribution of the CLR software. Authors should reference
-#' both this package,Montgomerie (2006), and the original reference(s).
+#' both this package, Montgomerie (2006), and the original reference(s).
 #' Description and notes on the measures:
 #'
 #' B1 (Total brightness): Sum of the relative reflectance over the entire spectral

--- a/R/summary.rspec.R
+++ b/R/summary.rspec.R
@@ -10,7 +10,9 @@
 #' of the complete output (composed of B2, S8 and H1; the variables described in
 #' Andersson and Prager 2006) are returned. Finally, a user-specified string of variable
 #' names can be used in order to filter and show only those variables.
-#' @param wlmin,wlmax minimum and maximum used to define the range of wavelengths used in
+#' @param lim vector specifying wavelength range to interpolate over (e.g.
+#'   `c(300, 700)`).
+#' @param wlmin,wlmax (deprecated) minimum and maximum used to define the range of wavelengths used in
 #' calculations (default is to use entire range in the `rspec` object).
 #' @param ... class consistency (ignored)
 #'
@@ -97,7 +99,7 @@
 #' results. Make sure chosen smoothing parameters are adequate.
 #' @note Smoothing affects only B3, S2, S4, S6, S10, H2, and H5 calculation. All other
 #' variables can be reliably extracted using non-smoothed data.
-#' 
+#'
 #' @importFrom stats quantile
 #'
 #' @export
@@ -158,21 +160,22 @@
 #' 13- Smiseth, P., J. Ornborg, S. Andersson, and T. Amundsen. 2001. Is male plumage reflectance
 #' correlated with paternal care in bluethroats? Behavioural Ecology 12:164-170.
 #'
-summary.rspec <- function(object, subset = FALSE, wlmin = NULL, wlmax = NULL, ...) {
+summary.rspec <- function(object, subset = FALSE, lim = c(300, 700), wlmin = NULL, wlmax = NULL, ...) {
   chkDots(...)
 
   wl <- isolate_wl(object, keep = "wl")
 
-  # Set WL min & max
-  lambdamin <- max(wlmin, min(wl))
-  lambdamax <- min(wlmax, max(wl))
-
-  if (!is.null(wlmin) && lambdamin > wlmin) {
-    stop("wlmin is smaller than the range of spectral data")
-  }
-  if (!is.null(wlmax) && lambdamax < wlmax) {
-    stop("wlmax is larger than the range of spectral data")
-  }
+  # Deprecate wlmin/wlmax
+  if (any(!is.null(wlmin), !is.null(wlmax))) {
+    warning("Arguments 'wlmin' and 'wlmax' are deprecated in favour of the single 'lim' argument, and will be removed in a future version.")
+    lim = c(wlmin, wlmax)
+  } 
+  
+  if (min(lim) < min(wl) || max(lim) > max(wl))
+    stop("Specified wavelemgth range exceeds that of the spectral data. Check the 'lim' argument.")
+  
+  lambdamin <- max(min(lim), min(wl))
+  lambdamax <- min(max(lim), max(wl))
 
   # Restrict to range of wlmin:wlmax
   object <- object[which(wl == lambdamin):which(wl == lambdamax), ]

--- a/man/summary.rspec.Rd
+++ b/man/summary.rspec.Rd
@@ -4,7 +4,14 @@
 \alias{summary.rspec}
 \title{Colourimetric variables}
 \usage{
-\method{summary}{rspec}(object, subset = FALSE, wlmin = NULL, wlmax = NULL, ...)
+\method{summary}{rspec}(
+  object,
+  subset = FALSE,
+  lim = c(300, 700),
+  wlmin = NULL,
+  wlmax = NULL,
+  ...
+)
 }
 \arguments{
 \item{object}{(required) a data frame, possibly an object of class \code{rspec},
@@ -17,7 +24,10 @@ of the complete output (composed of B2, S8 and H1; the variables described in
 Andersson and Prager 2006) are returned. Finally, a user-specified string of variable
 names can be used in order to filter and show only those variables.}
 
-\item{wlmin, wlmax}{minimum and maximum used to define the range of wavelengths used in
+\item{lim}{vector specifying wavelength range to interpolate over (e.g.
+\code{c(300, 700)}).}
+
+\item{wlmin, wlmax}{(deprecated) minimum and maximum used to define the range of wavelengths used in
 calculations (default is to use entire range in the \code{rspec} object).}
 
 \item{...}{class consistency (ignored)}

--- a/man/summary.rspec.Rd
+++ b/man/summary.rspec.Rd
@@ -25,7 +25,8 @@ Andersson and Prager 2006) are returned. Finally, a user-specified string of var
 names can be used in order to filter and show only those variables.}
 
 \item{lim}{vector specifying wavelength range to interpolate over (e.g.
-\code{c(300, 700)}).}
+\code{c(300, 700)}). Defaults to the entire range in the \code{rspec} object.
+Replaces the deprecated \code{wlmin} and \code{wlmax} arguments.}
 
 \item{wlmin, wlmax}{(deprecated) minimum and maximum used to define the range of wavelengths used in
 calculations (default is to use entire range in the \code{rspec} object).}
@@ -38,7 +39,7 @@ in Montgomerie (2006) with spectra name as row names.
 The colorimetric variables calculated by this function are
 described in Montgomerie (2006) with corrections included in the README CLR
 file from the May 2008 distribution of the CLR software. Authors should reference
-both this package,Montgomerie (2006), and the original reference(s).
+both this package, Montgomerie (2006), and the original reference(s).
 Description and notes on the measures:
 
 B1 (Total brightness): Sum of the relative reflectance over the entire spectral

--- a/tests/testthat/test-S3rspec.R
+++ b/tests/testthat/test-S3rspec.R
@@ -78,17 +78,16 @@ test_that("summary.rspec", {
   expect_named(summary(sicalis, subset = c("B1", "H4")), c("B1", "H4"))
 
   # Different wl ranges
-  expect_warning(summary(sicalis, wlmin = 500), "wavelength range not between")
-  expect_warning(summary(sicalis[1:200, ]), "wavelength range not between")
-  expect_warning(summary(sicalis, wlmax = 600), "wavelength range not between")
-  expect_error(summary(sicalis, wlmin = 200), "wlmin is smaller")
-  expect_error(summary(sicalis, wlmax = 1000), "wlmax is larger")
+  expect_warning(summary(sicalis, wlmin = 500, wlmax = 700), "deprecated")
+  expect_error(summary(sicalis[1:200, ]), "range exceeds")
+  expect_error(summary(sicalis, lim = c(200, 700)), "range exceeds")
+  expect_error(summary(sicalis, lim = c(300, 1000)), "range exceeds")
 
   # Test one spectrum rspec object
   one_spec <- sicalis[, c(1, 2)]
   expect_equal(dim(summary(one_spec)), c(1, 23))
   expect_length(
-    expect_warning(summary(one_spec, wlmin = 500), "blue chroma"),
+    expect_warning(summary(one_spec, lim = c(500, 700)), "blue chroma"),
     23
   )
 
@@ -96,7 +95,7 @@ test_that("summary.rspec", {
   expect_error(summary(sicalis, subset = "H9"), "do not match color variable names")
 
   # Warning about UV variables if full UV range is not included
-  expect_warning(summary(sicalis, wlmin = 350), "UV-related variables may not be meaningful")
+  expect_warning(summary(sicalis, lim = c(350, 700)), "UV-related variables may not be meaningful")
 })
 
 test_that("plot.rspec", {


### PR DESCRIPTION
Some ideas for tidying up & possibly expanding `summary.rspec()` (re: #165, in part). All up for discussion.

- [X] Deprecate `wlmin`, `wlmax`, in favour of `lim = c()` argument, for consistency. Might almost make life easer if we introduce custom chroma calculation(s), for which we'll need to take another wl range. 
- [X] Only calculate the variable(s) being returned, when using `subset`. (Update: not worth it for now)
- [ ] Add custom chroma? It'd need to take two ranges. Any other 'custom' variables which might be of use? Could also be spun off into it's own function, but it'd have to be worth it.
- [ ] Make sure that everything that should work with an arbitrary wl range (including NIR), does so.