### PR TITLE
Cie.fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 
 ## MINOR FEATURES AND BUG FIXES
 
+* CIE models now accept data created outside of `vismodel()`, by allowing users to 
+specify the illuminant and viewer sensitivity function used when estimating XYZ values 
+(via `illum` and `visual` arguments in `colspace()`).
 * `bootcoldist()` is now laxer in its argument checks and accept objects that 
 are neither `vismodel` or `colspace` objects. This means you can now use this 
 function on quantum catches dataframe that you obtained outside of pavo, such

--- a/R/cie.R
+++ b/R/cie.R
@@ -20,7 +20,7 @@
 #'  colour vision. Functions are linear transformations of the 10-degree cone fundamentals
 #'  of Stockman & Sharpe (2000), as ratified by the CIE (2006).
 #' @param illum the illuminant used when estimating XYZ values, if `vismodeldata` are
-#' not the result of a call to `vismodel()`. Either a data frame containing a `'wl'` column 
+#' not the result of a call to `vismodel()`. Either a data frame containing a `'wl'` column
 #' and the illuminant spectrum, or one of the built-in options:
 #' - `'D65'`: standard daylight.
 #' - `'bluesky'` open blue sky.
@@ -60,11 +60,10 @@
 #'  Parts 1 and 2. Technical Report 170-1. Vienna: Central Bureau of the Commission
 #'  Internationale de l Eclairage.
 
-cie <- function(vismodeldata, 
-                space = c("XYZ", "LAB", "LCh"), 
+cie <- function(vismodeldata,
+                space = c("XYZ", "LAB", "LCh"),
                 visual = c("cie2", "cie10"),
                 illum = c("D65", "bluesky", "forestshade")) {
-  
   space <- tryCatch(match.arg(space),
     error = function(e) {
       message("Invalid space arg. Defaulting to XYZ")
@@ -85,14 +84,14 @@ cie <- function(vismodeldata,
 
     # Calculate tristimulus values for neutral point. First need to
     # re-grab original sensitivity and illuminant data.
-    if('vismodel' %in% class(vismodeldata)){
+    if ("vismodel" %in% class(vismodeldata)) {
       S <- attr(vismodeldata, "data.visualsystem.chromatic")
       illum <- attr(vismodeldata, "data.illuminant") # Illuminant
-    }else{
+    } else {
       # Grab built-in data
       sens <- vissyst
       bgil <- bgandilum
-      
+
       # Match user-specified arguments
       visual2 <- tryCatch(
         match.arg(visual),
@@ -102,21 +101,21 @@ cie <- function(vismodeldata,
         match.arg(illum),
         error = function(e) "user-defined"
       )
-      
+
       # Grab the relevant data
       S <- switch(visual2,
-                  'user-defined' = isolate_wl(visual, keep = 'spec'),
-                  'cie2' = sens[, grep(visual2, names(sens))],
-                  'cie10' = sens[, grep(visual2, names(sens))]
-                  )
+        "user-defined" = isolate_wl(visual, keep = "spec"),
+        "cie2" = sens[, grep(visual2, names(sens))],
+        "cie10" = sens[, grep(visual2, names(sens))]
+      )
       illum <- switch(illum2,
-                     'user-defined' = isolate_wl(illum, keep = 'spec'),
-                     'D65' = bgil[, grep(illum2, names(bgil))],
-                     'bluesky' = bgil[, grep(illum2, names(bgil))],
-                     'forestshade' = bgil[, grep(illum2, names(bgil))]
-    )
+        "user-defined" = isolate_wl(illum, keep = "spec"),
+        "D65" = bgil[, grep(illum2, names(bgil))],
+        "bluesky" = bgil[, grep(illum2, names(bgil))],
+        "forestshade" = bgil[, grep(illum2, names(bgil))]
+      )
     }
-      
+
     Xn <- sum(S[, 1] * illum)
     Yn <- sum(S[, 2] * illum)
     Zn <- sum(S[, 3] * illum)

--- a/R/cie.R
+++ b/R/cie.R
@@ -20,8 +20,8 @@
 #'  colour vision. Functions are linear transformations of the 10-degree cone fundamentals
 #'  of Stockman & Sharpe (2000), as ratified by the CIE (2006).
 #' @param illum the illuminant used when estimating XYZ values, if `vismodeldata` are
-#' not the result of a call to `vismodel()` (otherwise the argument is ignored). 
-#' Either a data frame containing a `'wl'` column and the illuminant spectrum, or 
+#' not the result of a call to `vismodel()` (otherwise the argument is ignored).
+#' Either a data frame containing a `'wl'` column and the illuminant spectrum, or
 #' one of the built-in options:
 #' - `'D65'`: standard daylight.
 #' - `'bluesky'` open blue sky.
@@ -96,11 +96,17 @@ cie <- function(vismodeldata,
       # Match user-specified arguments
       visual2 <- tryCatch(
         match.arg(visual),
-        error = function(e) "user-defined"
+        error = function(e) {
+          message("Using custom visual system to estimate cie neutral point")
+          return("user-defined")
+        }
       )
       illum2 <- tryCatch(
         match.arg(illum),
-        error = function(e) "user-defined"
+        error = function(e) {
+          message("Using custom illuminant to estimate cie neutral point")
+          return("user-defined")
+        }
       )
 
       # Grab the relevant data

--- a/R/cie.R
+++ b/R/cie.R
@@ -8,7 +8,7 @@
 #'  data frame with three columns representing trichromatic viewer).
 #' @param space (required) Choice between XYZ (default), LAB, or LCh colour models.
 #' @param visual the visual system used when estimating XYZ values, if `vismodeldata` are
-#' not the result of a call to `vismodel()`. Options are:
+#' not the result of a call to `vismodel()` (otherwise the argument is ignored). Options are:
 #' - a data frame such as one produced containing by [sensmodel()], containing
 #'    user-defined sensitivity data for the receptors involved in colour vision.
 #'    The data frame must contain a `'wl'` column with the range of wavelengths included,
@@ -20,8 +20,9 @@
 #'  colour vision. Functions are linear transformations of the 10-degree cone fundamentals
 #'  of Stockman & Sharpe (2000), as ratified by the CIE (2006).
 #' @param illum the illuminant used when estimating XYZ values, if `vismodeldata` are
-#' not the result of a call to `vismodel()`. Either a data frame containing a `'wl'` column
-#' and the illuminant spectrum, or one of the built-in options:
+#' not the result of a call to `vismodel()` (otherwise the argument is ignored). 
+#' Either a data frame containing a `'wl'` column and the illuminant spectrum, or 
+#' one of the built-in options:
 #' - `'D65'`: standard daylight.
 #' - `'bluesky'` open blue sky.
 #' - `'forestshade'` forest shade.

--- a/R/cie.R
+++ b/R/cie.R
@@ -98,7 +98,6 @@ cie <- function(vismodeldata,
         match.arg(visual),
         error = function(e) "user-defined"
       )
-      print(visual2)
       illum2 <- tryCatch(
         match.arg(illum),
         error = function(e) "user-defined"
@@ -106,12 +105,12 @@ cie <- function(vismodeldata,
       
       # Grab the relevant data
       S <- switch(visual2,
-                  'user-defined' = prepare_userdefined(visual),
+                  'user-defined' = isolate_wl(visual, keep = 'spec'),
                   'cie2' = sens[, grep(visual2, names(sens))],
                   'cie10' = sens[, grep(visual2, names(sens))]
                   )
       illum <- switch(illum2,
-                     'user-defined' = prepare_userdefined(illum),
+                     'user-defined' = isolate_wl(illum, keep = 'spec'),
                      'D65' = bgil[, grep(illum2, names(bgil))],
                      'bluesky' = bgil[, grep(illum2, names(bgil))],
                      'forestshade' = bgil[, grep(illum2, names(bgil))]

--- a/R/cie.R
+++ b/R/cie.R
@@ -84,7 +84,7 @@ cie <- function(vismodeldata,
 
     # Calculate tristimulus values for neutral point. First need to
     # re-grab original sensitivity and illuminant data.
-    if ("vismodel" %in% class(vismodeldata)) {
+    if (inherits(vismodeldata, "vismodel")) {
       S <- attr(vismodeldata, "data.visualsystem.chromatic")
       illum <- attr(vismodeldata, "data.illuminant") # Illuminant
     } else {

--- a/R/colspace.R
+++ b/R/colspace.R
@@ -31,6 +31,7 @@
 #' ([plotting arguments][segplot])
 #' @param qcatch Which quantal catch metric is being inputted. Only used when
 #'   input data is NOT an output from [vismodel()]. Must be `Qi`, `fi` or `Ei`.
+#' @param ... additional arguments passed to [cie()] for non `vismodel()` data.
 #'
 #' @examples
 #' data(flowers)
@@ -92,7 +93,8 @@
 
 colspace <- function(vismodeldata,
                      space = c("auto", "di", "tri", "tcs", "hexagon", "coc", "categorical", "ciexyz", "cielab", "cielch", "segment"),
-                     qcatch = NULL) {
+                     qcatch = NULL, 
+                     ...) {
   space2 <- try(match.arg(space), silent = TRUE)
 
   if (inherits(space2, "try-error")) {
@@ -130,9 +132,9 @@ colspace <- function(vismodeldata,
       "tcs" = tcspace(vismodeldata),
       "coc" = coc(vismodeldata),
       "categorical" = categorical(vismodeldata),
-      "ciexyz" = cie(vismodeldata, "XYZ"),
-      "cielab" = cie(vismodeldata, "LAB"),
-      "cielch" = cie(vismodeldata, "LCh"),
+      "ciexyz" = cie(vismodeldata, "XYZ", ...),
+      "cielab" = cie(vismodeldata, "LAB", ...),
+      "cielch" = cie(vismodeldata, "LCh", ...),
       "segment" = segspace(vismodeldata)
     )
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -2,27 +2,6 @@
   packageStartupMessage("Welcome to pavo 2! Take a look at the latest features (and update your bibliography) in our recent publication: Maia R., Gruson H., Endler J. A., White T. E. (2019) pavo 2: new tools for the spectral and spatial analysis of colour in R. Methods in Ecology and Evolution, 10, 1097-1107.")
 }
 
-prepare_userdefined <- function(df) {
-  dfname <- deparse(substitute(df))
-  
-  if (is.rspec(df)) {
-    dfwhichused <- names(df)[2]
-    df <- df[, 2]
-    message(dfname, " is an rspec object; first spectrum (",
-            dQuote(dfwhichused), ") has been used (remaining columns ignored)",
-            call. = FALSE
-    )
-  } else if (is.data.frame(df) | is.matrix(df)) {
-    dfwhichused <- names(df)[1]
-    df <- df[, 1]
-    message(dfname, " is a matrix or data frame; first column (",
-            dQuote(dfwhichused), ") has been used (remaining columns ignored)",
-            call. = FALSE
-    )
-  }
-  return(df)
-}
-
 #####################
 # SUMMARY VARIABLES #
 #####################

--- a/R/internal.R
+++ b/R/internal.R
@@ -2,6 +2,27 @@
   packageStartupMessage("Welcome to pavo 2! Take a look at the latest features (and update your bibliography) in our recent publication: Maia R., Gruson H., Endler J. A., White T. E. (2019) pavo 2: new tools for the spectral and spatial analysis of colour in R. Methods in Ecology and Evolution, 10, 1097-1107.")
 }
 
+prepare_userdefined <- function(df) {
+  dfname <- deparse(substitute(df))
+  
+  if (is.rspec(df)) {
+    dfwhichused <- names(df)[2]
+    df <- df[, 2]
+    message(dfname, " is an rspec object; first spectrum (",
+            dQuote(dfwhichused), ") has been used (remaining columns ignored)",
+            call. = FALSE
+    )
+  } else if (is.data.frame(df) | is.matrix(df)) {
+    dfwhichused <- names(df)[1]
+    df <- df[, 1]
+    message(dfname, " is a matrix or data frame; first column (",
+            dQuote(dfwhichused), ") has been used (remaining columns ignored)",
+            call. = FALSE
+    )
+  }
+  return(df)
+}
+
 #####################
 # SUMMARY VARIABLES #
 #####################

--- a/R/vismodel.R
+++ b/R/vismodel.R
@@ -289,7 +289,7 @@ vismodel <- function(rspecdata,
     bkg <- rep(1, dim(rspecdata)[1])
   }
 
-  # Defining ocular transmission
+  # Defining ocular  <- mission
   trdat <- transmissiondata
 
   if (tr2 != "user-defined") {
@@ -311,23 +311,23 @@ vismodel <- function(rspecdata,
       }
     }
   }
-
+  
   prepare_userdefined <- function(df) {
     dfname <- deparse(substitute(df))
-
+    
     if (is.rspec(df)) {
       dfwhichused <- names(df)[2]
       df <- df[, 2]
       warning(dfname, " is an rspec object; first spectrum (",
-        dQuote(dfwhichused), ") has been used (remaining columns ignored)",
-        call. = FALSE
+              dQuote(dfwhichused), ") has been used (remaining columns ignored)",
+              call. = FALSE
       )
     } else if (is.data.frame(df) | is.matrix(df)) {
       dfwhichused <- names(df)[1]
       df <- df[, 1]
       warning(dfname, " is a matrix or data frame; first column (",
-        dQuote(dfwhichused), ") has been used (remaining columns ignored)",
-        call. = FALSE
+              dQuote(dfwhichused), ") has been used (remaining columns ignored)",
+              call. = FALSE
       )
     }
     return(df)

--- a/man/cie.Rd
+++ b/man/cie.Rd
@@ -4,7 +4,12 @@
 \alias{cie}
 \title{CIE colour spaces}
 \usage{
-cie(vismodeldata, space = c("XYZ", "LAB", "LCh"))
+cie(
+  vismodeldata,
+  space = c("XYZ", "LAB", "LCh"),
+  visual = c("cie2", "cie10"),
+  illum = c("D65", "bluesky", "forestshade")
+)
 }
 \arguments{
 \item{vismodeldata}{(required) quantum catch color data. Can be either the result
@@ -12,6 +17,30 @@ from \code{\link[=vismodel]{vismodel()}} or independently calculated data (in th
 data frame with three columns representing trichromatic viewer).}
 
 \item{space}{(required) Choice between XYZ (default), LAB, or LCh colour models.}
+
+\item{visual}{the visual system used when estimating XYZ values, if \code{vismodeldata} are
+not the result of a call to \code{vismodel()}. Options are:
+\itemize{
+\item a data frame such as one produced containing by \code{\link[=sensmodel]{sensmodel()}}, containing
+user-defined sensitivity data for the receptors involved in colour vision.
+The data frame must contain a \code{'wl'} column with the range of wavelengths included,
+and the sensitivity for each other cone as a column.
+\item \code{'cie2'}: 2-degree colour matching functions for CIE models of human
+colour vision. Functions are linear transformations of the 2-degree cone fundamentals
+of Stockman & Sharpe (2000), as ratified by the CIE (2006).
+\item \code{'cie10'}: 10-degree colour matching functions for CIE models of human
+colour vision. Functions are linear transformations of the 10-degree cone fundamentals
+of Stockman & Sharpe (2000), as ratified by the CIE (2006).
+}}
+
+\item{illum}{the illuminant used when estimating XYZ values, if \code{vismodeldata} are
+not the result of a call to \code{vismodel()}. Either a data frame containing a \code{'wl'} column
+and the illuminant spectrum, or one of the built-in options:
+\itemize{
+\item \code{'D65'}: standard daylight.
+\item \code{'bluesky'} open blue sky.
+\item \code{'forestshade'} forest shade.
+}}
 }
 \value{
 Object of class \code{\link{colspace}} containing:

--- a/man/cie.Rd
+++ b/man/cie.Rd
@@ -19,7 +19,7 @@ data frame with three columns representing trichromatic viewer).}
 \item{space}{(required) Choice between XYZ (default), LAB, or LCh colour models.}
 
 \item{visual}{the visual system used when estimating XYZ values, if \code{vismodeldata} are
-not the result of a call to \code{vismodel()}. Options are:
+not the result of a call to \code{vismodel()} (otherwise the argument is ignored). Options are:
 \itemize{
 \item a data frame such as one produced containing by \code{\link[=sensmodel]{sensmodel()}}, containing
 user-defined sensitivity data for the receptors involved in colour vision.
@@ -34,8 +34,9 @@ of Stockman & Sharpe (2000), as ratified by the CIE (2006).
 }}
 
 \item{illum}{the illuminant used when estimating XYZ values, if \code{vismodeldata} are
-not the result of a call to \code{vismodel()}. Either a data frame containing a \code{'wl'} column
-and the illuminant spectrum, or one of the built-in options:
+not the result of a call to \code{vismodel()} (otherwise the argument is ignored).
+Either a data frame containing a \code{'wl'} column and the illuminant spectrum, or
+one of the built-in options:
 \itemize{
 \item \code{'D65'}: standard daylight.
 \item \code{'bluesky'} open blue sky.

--- a/man/colspace.Rd
+++ b/man/colspace.Rd
@@ -8,7 +8,8 @@ colspace(
   vismodeldata,
   space = c("auto", "di", "tri", "tcs", "hexagon", "coc", "categorical", "ciexyz",
     "cielab", "cielch", "segment"),
-  qcatch = NULL
+  qcatch = NULL,
+  ...
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ See \code{\link[=categorical]{categorical()}} for details. (\link[=catplot]{plot
 
 \item{qcatch}{Which quantal catch metric is being inputted. Only used when
 input data is NOT an output from \code{\link[=vismodel]{vismodel()}}. Must be \code{Qi}, \code{fi} or \code{Ei}.}
+
+\item{...}{additional arguments passed to \code{\link[=cie]{cie()}} for non \code{vismodel()} data.}
 }
 \description{
 Models reflectance spectra in a colorspace. For information on plotting

--- a/man/summary.colspace.Rd
+++ b/man/summary.colspace.Rd
@@ -28,14 +28,18 @@ options specified when calculating the visual model. Also return the default
 in which case the following variables are output instead:
 \itemize{
 \item \verb{centroid.u, .s, .m, .l} the centroids of \code{usml} coordinates of points.
-\item \code{c.vol} the total volume occupied by the points.
-\item \code{rel.c.vol} volume occupied by the points relative to the tetrahedron volume.
+\item \code{c.vol} the total volume occupied by the points, computed with a convex
+hull.
+\item \code{rel.c.vol} volume occupied by the points (convex hull volume) relative to
+the tetrahedron volume.
 \item \code{colspan.m} the mean hue span.
 \item \code{colspan.v} the variance in hue span.
 \item \code{huedisp.m} the mean hue disparity.
 \item \code{huedisp.v} the variance in hue disparity.
 \item \code{mean.ra} mean saturation.
 \item \code{max.ra} maximum saturation achieved by the group of points.
+\item \code{a.vol} colour volume computed with
+\ifelse{html}{\out{&alpha;}}{\eqn{$\alpha$}{alpha}}‐shapes.
 }
 }
 \description{
@@ -64,6 +68,10 @@ The American Naturalist, 171(6), 755-776.
 
 Endler, J. A., & Mielke, P. (2005). Comparing entire colour patterns
 as birds see them. Biological Journal Of The Linnean Society, 86(4), 405-431.
+
+Gruson H. 2020. Estimation of colour volumes as concave hypervolumes using
+\ifelse{html}{\out{&alpha;}}{\eqn{$\alpha$}{alpha}}‐shapes. Methods in
+Ecology and Evolution, early view \doi{10.1111/2041-210X.13398}
 }
 \author{
 Rafael Maia \email{rm72@zips.uakron.edu}

--- a/man/voloverlap.Rd
+++ b/man/voloverlap.Rd
@@ -8,7 +8,7 @@ voloverlap(
   colsp1,
   colsp2,
   type = c("convex", "alpha"),
-  avalue,
+  avalue = "auto",
   plot = FALSE,
   interactive = FALSE,
   col = c("blue", "red", "darkgrey"),

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -179,6 +179,11 @@ test_that("CIE", {
                         Y = c(0.3, 0.4),
                         Z = c(0.5, 0.6),
                         lum = c(NA, NA))
-  colspace(fakedat, space = "cielab", visual = 'cie10', illum = sensdata(illum = 'D65'))
+  expect_equal(colspace(fakedat, space = "cielab", visual = sensdata(visual = 'cie10'), illum = sensdata(illum = 'D65')),
+               colspace(fakedat, space = "cielab", visual = 'cie10', illum = 'D65'))
+  
+  # Should ignore custom options when data are class vismodel()
+  expect_equal(colspace(vismodel(flowers, "cie10"), space = "cielab", visual = 'cie10', illum = 'D65'),
+               colspace(vismodel(flowers, "cie10"), space = "cielab", visual = 'cie2', illum = 'bluesky'))
 
 })

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -173,5 +173,12 @@ test_that("CIE", {
   expect_s3_class(implicit_cie_flowers, "colspace")
   explicit_cie_flowers <- colspace(vis_flowers, space = "ciexyz")
   expect_identical(implicit_cie_flowers, explicit_cie_flowers)
+  
+  # BYO data
+  fakedat <- data.frame(X = c(0.1, 0.2), 
+                        Y = c(0.3, 0.4),
+                        Z = c(0.5, 0.6),
+                        lum = c(NA, NA))
+  colspace(fakedat, space = "cielab", visual = 'cie10', illum = sensdata(illum = 'D65'))
 
 })

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -185,5 +185,9 @@ test_that("CIE", {
   # Should ignore custom options when data are class vismodel()
   expect_equal(colspace(vismodel(flowers, "cie10"), space = "cielab", visual = 'cie10', illum = 'D65'),
                colspace(vismodel(flowers, "cie10"), space = "cielab", visual = 'cie2', illum = 'bluesky'))
+  
+  # Message about the use of user-defined data
+  expect_message(colspace(fakedat, space = "cielab", illum = sensdata(illum = 'D65')), 'custom illuminant')
+  expect_message(colspace(fakedat, space = "cielab", visual = sensdata(visual = 'cie10')), 'custom visual system')
 
 })


### PR DESCRIPTION
No doubt some things that can be tidied/tweaked, but this seems to fix the main problem of users not being able to use `cie` models with non-vismodel data. They can now either specify their own illuminant and/or viewer, or use one of the built-ins. 

If you get a chance, let me know if anything jumps out, otherwise I'll go over it with fresh eyes in the next day or two and merge it in. Can always tweak small things later as they arise.