### PR TITLE
Replace rgl.triangles with triangles3d

### DIFF
--- a/R/tcsvol.R
+++ b/R/tcsvol.R
@@ -61,7 +61,7 @@ tcsvol <- function(tcsdata, type = c("convex", "alpha"), avalue = "auto",
   }
 
   if (fill) {
-    rgl::rgl.triangles(coords[vol, ],
+    rgl::triangles3d(coords[vol, ],
       alpha = alpha, color = col
     )
   }


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to pavo. 
I will be deprecating a number of rgl.* function calls.  You can read 
about the issues here:

   https://dmurdoch.github.io/rgl/articles/deprecation.html

pavo uses rgl.triangles in one spot; I have made the required changes in the attached patch.