### PR TITLE
Make sure colcat() works for x = 0 and y = 0

### DIFF
--- a/R/categorical.R
+++ b/R/categorical.R
@@ -115,8 +115,8 @@ categorical <- function(vismodeldata) {
     }
 
     paste0(
-      ifelse(object$x > 0, "p+y", "p-y"),
-      ifelse(object$y > 0, "+", "-")
+      ifelse(object$x > 0, "p+", "p-"),
+      ifelse(object$y > 0, "y+", "y-")
     )
   }
 

--- a/R/categorical.R
+++ b/R/categorical.R
@@ -111,7 +111,7 @@ categorical <- function(vismodeldata) {
       return(ifelse(object$y > 0, "y+", "y-"))
     }
     if (object$y == 0) {
-      return(ifelse(object$x > 0, "x+", "x-"))
+      return(ifelse(object$x > 0, "p+", "p-"))
     }
 
     paste0(

--- a/R/categorical.R
+++ b/R/categorical.R
@@ -105,7 +105,7 @@ categorical <- function(vismodeldata) {
   # Colour category calculator
   colcat <- function(object) {
     if (object$x == 0 && object$y == 0) {
-      return(NA)
+      return(NA_character_)
     }
     if (object$x == 0) {
       return(ifelse(object$y > 0, "y+", "y-"))
@@ -113,7 +113,7 @@ categorical <- function(vismodeldata) {
     if (object$y == 0) {
       return(ifelse(object$x > 0, "x+", "x-"))
     }
-    
+
     paste0(
       ifelse(object$x > 0, "p+y", "p-y"),
       ifelse(object$y > 0, "+", "-")

--- a/tests/testthat/test-colspace.R
+++ b/tests/testthat/test-colspace.R
@@ -44,6 +44,15 @@ test_that("Receptor orders & names", {
   )
 })
 
+test_that("colcat()", {
+
+  # https://github.com/rmaia/pavo/issues/244
+  # colcat() works even for points close to the origin
+  test <- data.frame(u = 0, s = 0, m = 0, l = 0)
+  expect_no_error(colspace(test, space = "categorical"))
+
+})
+
 test_that("Relative quantum catches", {
   data(flowers)
 


### PR DESCRIPTION
Follow up of 813622edf1d94b4bc1f600d55388876b86ec22c2:

- adds a test to ensure we don't reintroduce this bug in the future
- fix the case when x = 0 and y = 0. The test added in the previous commit reveals that `NA` is by default coerced to `NA_logical_` which still causes issues in the `vapply()` call
- move `y` to the second `ifelse()` call to clarify that x & y are handled symmetrically
- use p+/p- rather x+/x- when y = 0 for consistency

Fix #244 