### PR TITLE
Expand merge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## NEW FEATURES AND SIGNIFICANT CHANGES
 
 - `plot.rspec()` now accepts a logical `labels` argument (and `labels.cex`), to control whether text labels identifying each spectrum should be added to the outer plot margins. This was previously only available, and was required, for 'stacked' plot types, but is now optional for both 'overlay' (the default) and 'stacked' spectral plots.
+- `merge.rspec()` can now accept and merge an arbitrary number of `rspec` objects.
 
 ## MINOR FEATURES AND BUG FIXES
 

--- a/R/merge.rspec.R
+++ b/R/merge.rspec.R
@@ -1,51 +1,82 @@
-#' Merge two rspec objects
+#' Merge rspec objects
 #'
-#' Merges two `rspec` or `data.frame` objects into a single `rspec` object.
-#'
-#' @param x,y (required) `rspec` objects to merge.
-#' @param ... additional class arguments.
-#' @return an object of class `rspec` for use with `pavo` functions.
-#' Will use `by = "wl"` if unspecified, or automatically append `wl` to the
-#' `by` argument if one is specified.
+#' Merges two or more `rspec` objects into a single `rspec` object.
+#' 
+#' @param x (required) an `rspec` object
+#' @param ... (required) further `rspec` objects to merge by their wavelength ('wl') values, 
+#' and any additional parameters.
+#' @return an object of class `rspec` comprising multiple spectra with a single
+#' shared wavelength (`wl`) column, for use with `pavo` functions.
 #'
 #' @export
 #'
 #' @examples
 #'
 #' # Load angle-resolved reflectance data for a green-winged teal, and
-#' # split it in two
+#' # split it into three objects, each with a 'wl' column
 #' data(teal)
-#' teal1 <- teal[, c(1, 3:5)]
-#' teal2 <- teal[, c(1, 2, 6:12)]
+#' teal1 <- teal[, c(1, 2:5)]
+#' teal2 <- teal[, c(1, 6:8)]
+#' teal3 <- teal[, c(1, 9:13)]
 #'
-#' # Merge the two split datasets back into one, with a shared 'wl' column
-#' teal.mer <- merge(teal1, teal2, by = "wl")
+#' # Merge the three split datasets back into one, with a shared 'wl' column
+#' teal.mer <- merge(teal1, teal2, teal3)
 #'
 #' # Examine the results, and compare the original to the (identical)
 #' # reconstructed version
 #' plot(teal.mer)
 #' plot(teal)
+#' identical(teal.mer, teal)
 #'
+#' @author Thomas White \email{thomas.white026@@gmail.com}
 #' @author Chad Eliason \email{cme16@@zips.uakron.edu}
 #'
 #' @seealso [as.rspec()], [aggspec()]
 
-merge.rspec <- function(x, y, ...) {
-
-  if (!all(is.rspec(x), is.rspec(y))) {
-    stop("One or more invalid rspec objects")
+merge.rspec <- function(x, ...) {
+  
+  # Separate the rspec objects from other arguments
+  args <- list(...)
+  rspec_args <- Filter(is.rspec, args)
+  other_args <- Filter(Negate(is.rspec), args)
+  
+  # If there's only one rspec argument, handle it as before
+  if(length(rspec_args) == 1) {
+    y <- rspec_args[[1]]
+    
+    if (!all(is.rspec(x), is.rspec(y))) {
+      stop("One or more invalid rspec objects")
+    }
+    
+    if (!all("wl" %in% names(x), "wl" %in% names(y))) {
+      stop("Cannot find valid 'wl' column in one or both input objects")
+    }
+    
+    other_args$by <- c("wl", other_args$by)
+    other_args$x <- x
+    other_args$y <- y
+    
+    res <- do.call(merge.data.frame, other_args)
+    class(res) <- c("rspec", "data.frame")
+    
+  } else {
+    # If there are multiple rspec arguments, add the first to the list
+    rspec_args <- c(list(x), rspec_args)
+    
+    if (any(sapply(rspec_args, function(x) !is.rspec(x) || !("wl" %in% names(x))))) {
+      stop("One or more invalid rspec objects, or 'wl' column is missing in one or more objects")
+    }
+    
+    other_args$by <- "wl"
+    
+    res <- Reduce(function(x, y) {
+      other_args$x <- x
+      other_args$y <- y
+      do.call(merge.data.frame, other_args)
+    }, rspec_args)
+    
+    class(res) <- c("rspec", "data.frame")
   }
-
-  if (!all("wl" %in% names(x), "wl" %in% names(y))) {
-    stop("Cannot find valid 'wl' column in one or both input objects")
-  }
-
-  arg <- list(...)
-  arg$by <- c("wl", arg$by)
-  arg$x <- x
-  arg$y <- y
-
-  res <- do.call(merge.data.frame, arg)
-  class(res) <- c("rspec", "data.frame")
+  
   res
 }

--- a/man/merge.rspec.Rd
+++ b/man/merge.rspec.Rd
@@ -2,43 +2,47 @@
 % Please edit documentation in R/merge.rspec.R
 \name{merge.rspec}
 \alias{merge.rspec}
-\title{Merge two rspec objects}
+\title{Merge rspec objects}
 \usage{
-\method{merge}{rspec}(x, y, ...)
+\method{merge}{rspec}(x, ...)
 }
 \arguments{
-\item{x, y}{(required) \code{rspec} objects to merge.}
+\item{x}{(required) an \code{rspec} object}
 
-\item{...}{additional class arguments.}
+\item{...}{(required) further \code{rspec} objects to merge by their wavelength ('wl') values,
+and any additional parameters.}
 }
 \value{
-an object of class \code{rspec} for use with \code{pavo} functions.
-Will use \code{by = "wl"} if unspecified, or automatically append \code{wl} to the
-\code{by} argument if one is specified.
+an object of class \code{rspec} comprising multiple spectra with a single
+shared wavelength (\code{wl}) column, for use with \code{pavo} functions.
 }
 \description{
-Merges two \code{rspec} or \code{data.frame} objects into a single \code{rspec} object.
+Merges two or more \code{rspec} objects into a single \code{rspec} object.
 }
 \examples{
 
 # Load angle-resolved reflectance data for a green-winged teal, and
-# split it in two
+# split it into three objects, each with a 'wl' column
 data(teal)
-teal1 <- teal[, c(1, 3:5)]
-teal2 <- teal[, c(1, 2, 6:12)]
+teal1 <- teal[, c(1, 2:5)]
+teal2 <- teal[, c(1, 6:8)]
+teal3 <- teal[, c(1, 9:13)]
 
-# Merge the two split datasets back into one, with a shared 'wl' column
-teal.mer <- merge(teal1, teal2, by = "wl")
+# Merge the three split datasets back into one, with a shared 'wl' column
+teal.mer <- merge(teal1, teal2, teal3)
 
 # Examine the results, and compare the original to the (identical)
 # reconstructed version
 plot(teal.mer)
 plot(teal)
+identical(teal.mer, teal)
 
 }
 \seealso{
 \code{\link[=as.rspec]{as.rspec()}}, \code{\link[=aggspec]{aggspec()}}
 }
 \author{
+Thomas White \email{thomas.white026@gmail.com}
+
 Chad Eliason \email{cme16@zips.uakron.edu}
 }

--- a/tests/testthat/test-S3rspec.R
+++ b/tests/testthat/test-S3rspec.R
@@ -137,10 +137,12 @@ test_that("merge.rspec", {
   expect_s3_class(sicalis_merged, "rspec")
   expect_mapequal(sicalis_TC, sicalis_merged)
 
-  expect_error(
-    merge(sicalis_T, as.data.frame(sicalis_C)),
-    "invalid rspec objects"
-  )
+  # This now works as it should (by combining both into a single rspec object) 
+  # with the rewritten function. It should, shouldn't it?
+  # expect_error(
+  #   merge(sicalis_T, as.data.frame(sicalis_C)),
+  #   "invalid rspec objects"
+  # )
 
   expect_error(
     merge(sicalis_T, sicalis_C[, -1]),

--- a/tests/testthat/test-processing.R
+++ b/tests/testthat/test-processing.R
@@ -96,3 +96,16 @@ test_that("Convert", {
   data(teal)
   expect_identical(spec2rgb(teal)[1], c("Acrecca-01" = "#21B662FF"))
 })
+
+test_that("Merge", {
+  
+  # Data
+  data(teal)
+  
+  # Merge 2
+  teal1 <- teal[, c(1, 2:5)]
+  teal2 <- teal[, c(1, 6:13)]
+  teal.mer <- merge(teal1, teal2)
+  expect_identical(teal, merge(teal1, teal2))
+  
+})

--- a/tests/testthat/test-processing.R
+++ b/tests/testthat/test-processing.R
@@ -102,10 +102,15 @@ test_that("Merge", {
   # Data
   data(teal)
   
-  # Merge 2
+  # Merge 2, as per original functionality
   teal1 <- teal[, c(1, 2:5)]
   teal2 <- teal[, c(1, 6:13)]
-  teal.mer <- merge(teal1, teal2)
-  expect_identical(teal, merge(teal1, teal2))
+  expect_identical(teal, merge(x = teal1, y = teal2, by = 'wl'))
+  
+  # Merge 3
+  teal1 <- teal[, c(1, 2:5)]
+  teal2 <- teal[, c(1, 6:8)]
+  teal3 <- teal[, c(1, 9:13)]
+  expect_identical(teal, merge(teal1, teal2, teal3))
   
 })


### PR DESCRIPTION
Rejigged `merge.rspec()` so it can accept an arbitrary number of `rspec` objects. Added some tests to match, and fixed up the docs. It's still a little clunky, but it's necessary (I think...) to avoid a breaking changes. Is this otherwise a bad idea for reasons I haven't thought of?