### PR TITLE
Create check-cran-deadline GHA workflow

### DIFF
--- a/.github/workflows/check-cran-deadline.yaml
+++ b/.github/workflows/check-cran-deadline.yaml
@@ -1,0 +1,50 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 1 * * *'
+
+name: check-cran-deadline
+
+jobs:
+  fetch-deadlines:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      issues: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: gh
+
+      - name: Fetch deadline for this package
+        shell: Rscript {0}
+        run: |
+          crandb <- tools::CRAN_package_db()
+
+          deadline <- crandb[Package == "pavo", "Deadline"]
+
+          if (!is.na(deadline)) {
+            gh::gh(
+              "POST /repos/{owner}/{repo}/issues",
+              owner = "rmaia",
+              repo = "pavo",
+              title = paste("Fix CRAN R CMD check issues by", deadline),
+              body = "This GHA workflow has been disabled. Please re-enable it when closing this issue."
+            )
+            gh::gh(
+              "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
+              owner = "rmaia",
+              pavo = "pavo",
+              workflow_id = "check-cran-deadline.yaml"
+            )
+          }


### PR DESCRIPTION
This is an experimental workflow to open a new GitHub issue when CRAN sets a deadline to fix R CMD check for pavo.

It would allow me or any other contributor to chip in and investigate the issue even if the maintainer is not immediately available.