### PR TITLE
Expand sensmodel() to add further templates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -35,5 +35,6 @@ CONDUCT.md
 ^vignettes/drafts$
 ^data-raw$
 ^\.lintr$
+^\.claude$
 ^CRAN-SUBMISSION$
 ^README\.qmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,4 @@ Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -77,72 +77,86 @@ export(voloverlap)
 importFrom(cluster,clara)
 importFrom(farver,compare_colour)
 importFrom(future.apply,future_lapply)
-importFrom(geometry,bary2cart)
-importFrom(geometry,convhulln)
-importFrom(geometry,intersectn)
-importFrom(grDevices,adjustcolor)
-importFrom(grDevices,as.raster)
-importFrom(grDevices,col2rgb)
-importFrom(grDevices,colorRampPalette)
-importFrom(grDevices,convertColor)
-importFrom(grDevices,dev.new)
-importFrom(grDevices,dev.off)
-importFrom(grDevices,n2mfrow)
-importFrom(grDevices,rgb)
-importFrom(grDevices,trans3d)
-importFrom(graphics,abline)
-importFrom(graphics,arrows)
-importFrom(graphics,axis)
-importFrom(graphics,box)
-importFrom(graphics,grconvertX)
-importFrom(graphics,grconvertY)
-importFrom(graphics,image)
-importFrom(graphics,legend)
-importFrom(graphics,lines)
-importFrom(graphics,locator)
-importFrom(graphics,mtext)
-importFrom(graphics,par)
-importFrom(graphics,plot.default)
-importFrom(graphics,plot.new)
-importFrom(graphics,plot.window)
-importFrom(graphics,points)
-importFrom(graphics,polygon)
-importFrom(graphics,rasterImage)
-importFrom(graphics,segments)
-importFrom(graphics,text)
-importFrom(graphics,title)
+importFrom(geometry,
+  bary2cart,
+  convhulln,
+  intersectn
+)
+importFrom(grDevices,
+  adjustcolor,
+  as.raster,
+  col2rgb,
+  colorRampPalette,
+  convertColor,
+  dev.new,
+  dev.off,
+  n2mfrow,
+  rgb,
+  trans3d
+)
+importFrom(graphics,
+  abline,
+  arrows,
+  axis,
+  box,
+  grconvertX,
+  grconvertY,
+  image,
+  legend,
+  lines,
+  locator,
+  mtext,
+  par,
+  plot.default,
+  plot.new,
+  plot.window,
+  points,
+  polygon,
+  rasterImage,
+  segments,
+  text,
+  title
+)
 importFrom(lightr,lr_get_spec)
-importFrom(magick,image_data)
-importFrom(magick,image_flop)
-importFrom(magick,image_info)
-importFrom(magick,image_read)
-importFrom(magick,image_resize)
-importFrom(magick,image_rotate)
+importFrom(magick,
+  image_data,
+  image_flop,
+  image_info,
+  image_read,
+  image_resize,
+  image_rotate
+)
 importFrom(plot3D,perspbox)
-importFrom(progressr,progressor)
-importFrom(progressr,with_progress)
-importFrom(stats,aggregate)
-importFrom(stats,approx)
-importFrom(stats,cor)
-importFrom(stats,dist)
-importFrom(stats,fft)
-importFrom(stats,kmeans)
-importFrom(stats,loess)
-importFrom(stats,loess.smooth)
-importFrom(stats,median)
-importFrom(stats,na.omit)
-importFrom(stats,pnorm)
-importFrom(stats,predict)
-importFrom(stats,qnorm)
-importFrom(stats,quantile)
-importFrom(stats,runif)
-importFrom(stats,sd)
-importFrom(stats,setNames)
-importFrom(stats,var)
+importFrom(progressr,
+  progressor,
+  with_progress
+)
+importFrom(stats,
+  aggregate,
+  approx,
+  cor,
+  dist,
+  fft,
+  kmeans,
+  loess,
+  loess.smooth,
+  median,
+  na.omit,
+  pnorm,
+  predict,
+  qnorm,
+  quantile,
+  runif,
+  sd,
+  setNames,
+  var
+)
 importFrom(tools,file_path_sans_ext)
-importFrom(utils,combn)
-importFrom(utils,hasName)
-importFrom(utils,head)
-importFrom(utils,modifyList)
-importFrom(utils,object.size)
-importFrom(utils,tail)
+importFrom(utils,
+  combn,
+  hasName,
+  head,
+  modifyList,
+  object.size,
+  tail
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,18 +6,21 @@
   template used to generate sensitivity curves. It names both the author and the
   chromophore, since a template's shape depends on both, and defaults to
   `"govardovskii_a1"`, which is what every previous version of the function used.
-  `"ssh_a1"` and `"ssh_a2"` add the Stavenga, Smits and Hoenders (1993)
-  templates. The A2 template covers porphyropsin pigments, found in freshwater
-  fish, amphibians, and species that switch chromophore seasonally, which pavo
-  previously could not model at all. An A2 band is around 19% broader than the A1
-  band at the same peak sensitivity, so it is not recovered by adjusting
-  `peaksens`. The template used is recorded as a `"template"` attribute on the
-  result. Note that `beta = FALSE` is recommended with either SSH template: their
-  beta band has a fixed peak wavelength rather than one that scales with
-  `peaksens`, so for short-wavelength pigments it pulls the maximum of the summed
-  curve several nm away from the value asked for. The alpha band on its own is
-  unaffected, and Stavenga (2010) notes the fixed beta peak to be a known
-  shortcoming of the template.
+  `"govardovskii_a2"` adds the vitamin A2 template from the same paper, and
+  `"ssh_a1"` and `"ssh_a2"` the two from Stavenga, Smits and Hoenders (1993). The
+  A2 templates cover porphyropsin pigments, found in freshwater fish, amphibians,
+  and species that switch chromophore seasonally, which pavo previously could not
+  model at all: an A2 band is close to 20% broader than the A1 band at the same
+  peak sensitivity, so it is not recovered by adjusting `peaksens`.
+  `"govardovskii_a2"` is the one to reach for, since pairing it with the default
+  compares chromophores without also changing template family. The template used
+  is recorded as a `"template"` attribute on the result. Note that
+  `beta = FALSE` is recommended with either SSH template: their beta band has a
+  fixed peak wavelength rather than one that scales with `peaksens`, so for
+  short-wavelength pigments it pulls the maximum of the summed curve several nm
+  away from the value asked for. The alpha band on its own is unaffected, both
+  Govardovskii beta bands scale with `peaksens` and do not have this problem, and
+  Stavenga (2010) notes the fixed beta peak to be a known shortcoming.
 - `bootcoldist()` now summarises `colspace()` objects by the arithmetic mean of
   their coordinates, rather than by a geometric mean of those coordinates shifted
   by an arbitrary constant of 100. Distances between points in a colour space are

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## NEW FEATURES AND SIGNIFICANT CHANGES
 
+- `sensmodel()` gains a `template` argument, selecting the visual pigment
+  template used to generate sensitivity curves. It names both the author and the
+  chromophore, since a template's shape depends on both, and defaults to
+  `"govardovskii_a1"`, which is what every previous version of the function used.
+  `"ssh_a1"` and `"ssh_a2"` add the Stavenga, Smits and Hoenders (1993)
+  templates. The A2 template covers porphyropsin pigments, found in freshwater
+  fish, amphibians, and species that switch chromophore seasonally, which pavo
+  previously could not model at all. An A2 band is around 19% broader than the A1
+  band at the same peak sensitivity, so it is not recovered by adjusting
+  `peaksens`. The template used is recorded as a `"template"` attribute on the
+  result. Note that `beta = FALSE` is recommended with either SSH template: their
+  beta band has a fixed peak wavelength rather than one that scales with
+  `peaksens`, so for short-wavelength pigments it pulls the maximum of the summed
+  curve several nm away from the value asked for. The alpha band on its own is
+  unaffected, and Stavenga (2010) notes the fixed beta peak to be a known
+  shortcoming of the template.
 - `bootcoldist()` now summarises `colspace()` objects by the arithmetic mean of
   their coordinates, rather than by a geometric mean of those coordinates shifted
   by an arbitrary constant of 100. Distances between points in a colour space are

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,9 +18,10 @@
   `beta = FALSE` is recommended with either SSH template: their beta band has a
   fixed peak wavelength rather than one that scales with `peaksens`, so for
   short-wavelength pigments it pulls the maximum of the summed curve several nm
-  away from the value asked for. The alpha band on its own is unaffected, both
-  Govardovskii beta bands scale with `peaksens` and do not have this problem, and
-  Stavenga (2010) notes the fixed beta peak to be a known shortcoming.
+  away from the value asked for, and `sensmodel()` warns where that shift exceeds
+  5 nm. The alpha band on its own is unaffected, both Govardovskii beta bands
+  scale with `peaksens` and do not have this problem, and Stavenga (2010) notes
+  the fixed beta peak to be a known shortcoming.
 - `bootcoldist()` now summarises `colspace()` objects by the arithmetic mean of
   their coordinates, rather than by a geometric mean of those coordinates shifted
   by an arbitrary constant of 100. Distances between points in a colour space are

--- a/R/sensmodel-templates.R
+++ b/R/sensmodel-templates.R
@@ -30,7 +30,8 @@
 
 sens_template <- function(template, peaksens, wlmat, beta) {
   switch(template,
-    govardovskii_a1 = sens_govardovskii(peaksens, wlmat, beta),
+    govardovskii_a1 = sens_govardovskii(peaksens, wlmat, beta, chromophore = "A1"),
+    govardovskii_a2 = sens_govardovskii(peaksens, wlmat, beta, chromophore = "A2"),
     ssh_a1 = sens_ssh(peaksens, wlmat, beta, chromophore = "A1"),
     ssh_a2 = sens_ssh(peaksens, wlmat, beta, chromophore = "A2"),
     stop("unknown template '", template, "'", call. = FALSE)
@@ -38,28 +39,62 @@ sens_template <- function(template, peaksens, wlmat, beta) {
 }
 
 
-# Govardovskii et al. (2000), vitamin A1 chromophore.
+# Govardovskii et al. (2000).
 #
-# The alpha band is equation 2 of Stavenga (2010), which restates Govardovskii
-# et al. (2000). The 300 in the `a` term is a constant of that expression, not a
-# reference to the `range` argument of sensmodel(); coding it as `range[1]`
-# applies the short-wavelength narrowing correction according to the requested
-# range rather than the pigment's peak sensitivity, which was the bug fixed in
-# pavo 2.10.0. The beta band is Govardovskii's Gaussian, whose peak wavelength
-# and width both scale with peaksens.
-sens_govardovskii <- function(peaksens, wlmat, beta = TRUE) {
+# The alpha band is their equation 1, a form due to Lamb (1995), refitted. Under
+# the Mansfield-MacNichol transform the parameters governing the long-wave slope
+# would be constant; they are not, so Govardovskii et al. make them functions of
+# peaksens. For A1 that is `a` alone, their equation 2; for A2 it is both `A` and
+# `a`, their equations 6a and 6b, and the remaining five constants differ too.
+#
+# The 300 in the A1 `a` term is a constant of that expression, not a reference to
+# the `range` argument of sensmodel(); coding it as `range[1]` applies the
+# short-wavelength narrowing correction according to the requested range rather
+# than the pigment's peak sensitivity, which was the bug fixed in pavo 2.10.0.
+#
+# The beta band is their equation 4, a Gaussian whose peak wavelength and width
+# are both linear in peaksens for A1 (equations 5a, 5b); for A2 the peak is
+# linear but the width is quadratic (equations 8a, 8b), and the amplitude is
+# higher. Because both scale with peaksens, neither chromophore suffers the peak
+# displacement that the fixed-wavelength SSH beta band produces.
+#
+# Fitted over lmax 357-620 nm. The A2 sample spans roughly 440-620 nm.
+sens_govardovskii <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") {
   x <- peaksens / wlmat
 
-  a <- 0.8795 + 0.0459 * exp(-(peaksens - 300)^2 / 11940)
+  if (identical(chromophore, "A1")) {
+    A <- 69.7
+    a <- 0.8795 + 0.0459 * exp(-(peaksens - 300)^2 / 11940)
+    B <- 28
+    b <- 0.922
+    Cc <- -14.9
+    cc <- 1.104
+    D <- 0.674
 
-  peaks <- 1 / (exp(69.7 * (a - x)) +
-    exp(28 * (0.922 - x)) +
-    exp(-14.9 * (1.104 - x)) +
-    0.674)
+    beta_amp <- 0.26
+    beta_peak <- 189 + 0.315 * peaksens
+    beta_width <- -40.5 + 0.195 * peaksens
+  } else {
+    A <- 62.7 + 1.834 * exp((peaksens - 625) / 54.2)
+    a <- 0.875 + 0.0268 * exp((peaksens - 665) / 40.7)
+    B <- 20.85
+    b <- 0.9101
+    Cc <- -10.37
+    cc <- 1.1123
+    D <- 0.5343
+
+    beta_amp <- 0.37
+    beta_peak <- 216.7 + 0.287 * peaksens
+    beta_width <- 317 - 1.149 * peaksens + 0.00124 * peaksens^2
+  }
+
+  peaks <- 1 / (exp(A * (a - x)) +
+    exp(B * (b - x)) +
+    exp(Cc * (cc - x)) +
+    D)
 
   if (beta) {
-    betabands <- 0.26 * exp(-((wlmat - (189 + 0.315 * peaksens)) /
-      (-40.5 + 0.195 * peaksens))^2)
+    betabands <- beta_amp * exp(-((wlmat - beta_peak) / beta_width)^2)
     peaks <- peaks + betabands
   }
 

--- a/R/sensmodel-templates.R
+++ b/R/sensmodel-templates.R
@@ -29,13 +29,20 @@
 
 
 sens_template <- function(template, peaksens, wlmat, beta) {
-  switch(template,
+  # switch() returns NULL when nothing matches and no default is given, which
+  # keeps the error out of the switch call itself
+  out <- switch(template,
     govardovskii_a1 = sens_govardovskii(peaksens, wlmat, beta, chromophore = "A1"),
     govardovskii_a2 = sens_govardovskii(peaksens, wlmat, beta, chromophore = "A2"),
     ssh_a1 = sens_ssh(peaksens, wlmat, beta, chromophore = "A1"),
-    ssh_a2 = sens_ssh(peaksens, wlmat, beta, chromophore = "A2"),
-    stop("unknown template '", template, "'", call. = FALSE)
+    ssh_a2 = sens_ssh(peaksens, wlmat, beta, chromophore = "A2")
   )
+
+  if (is.null(out)) {
+    stop("unknown template '", template, "'", call. = FALSE)
+  }
+
+  out
 }
 
 

--- a/R/sensmodel-templates.R
+++ b/R/sensmodel-templates.R
@@ -1,6 +1,6 @@
-########################
+############################
 # VISUAL PIGMENT TEMPLATES #
-########################
+############################
 
 # Internal template functions used by sensmodel().
 #
@@ -22,6 +22,20 @@
 #   return value need not be normalised: sensmodel() peak-normalises every
 #   template to a maximum of 1 before applying oil droplets, ocular media and
 #   integration, all of which are template-agnostic.
+#
+# Chromophore is part of the template name rather than a separate argument,
+# because support for it is ragged: templates not yet implemented here are
+# A1-only (Lamb 1995, Baylor et al. 1987), while SSH also covers A4.
+
+
+sens_template <- function(template, peaksens, wlmat, beta) {
+  switch(template,
+    govardovskii_a1 = sens_govardovskii(peaksens, wlmat, beta),
+    ssh_a1 = sens_ssh(peaksens, wlmat, beta, chromophore = "A1"),
+    ssh_a2 = sens_ssh(peaksens, wlmat, beta, chromophore = "A2"),
+    stop("unknown template '", template, "'", call. = FALSE)
+  )
+}
 
 
 # Govardovskii et al. (2000), vitamin A1 chromophore.
@@ -47,6 +61,66 @@ sens_govardovskii <- function(peaksens, wlmat, beta = TRUE) {
     betabands <- 0.26 * exp(-((wlmat - (189 + 0.315 * peaksens)) /
       (-40.5 + 0.195 * peaksens))^2)
     peaks <- peaks + betabands
+  }
+
+  peaks
+}
+
+
+# Stavenga, Smits & Hoenders (1993), "SSH".
+#
+# Band shape is their equation 2, a modified lognormal in log10(lambda/lambdamax)
+# with the restriction a2 = 3 * a1^2 / 8, which leaves the log absorbance of each
+# band with a single inflection point. Coefficients are their Table 1.
+#
+# Two things differ from Govardovskii and matter to callers:
+#
+# 1. The beta band has a *fixed* peak wavelength rather than one that scales with
+#    peaksens. Stavenga et al. use 350 nm for A1 in their predictions (their
+#    Fig. 4), restated in Stavenga (2010); the 340 nm in Table 1 is the value
+#    fitted to bovine rhodopsin specifically, not the value used for prediction.
+#    For A2 no prediction value is published, so the Table 1 fit to carp
+#    porphyropsin (368 nm) is used. A fixed beta band distorts the summed curve
+#    for short-wavelength pigments, so sensmodel() checks peak recovery and warns.
+#
+# 2. Table 1 also lists a gamma band for A1 and A4. It is excluded here: it peaks
+#    near 276 nm, outside the default range of sensmodel(), and Govardovskii has
+#    no gamma term, so including it would make the templates non-comparable.
+#
+# A4 coefficients are stored but not reachable from sensmodel(), pending a use
+# case. Note this is A4 (Table 1 of the paper), not the more widely encountered
+# A3 chromophore of many insects.
+ssh_bands <- list(
+  A1 = list(
+    alpha = c(A = 1, a0 = 380, a1 = 6.09),
+    beta = c(A = 0.29, a0 = 247, a1 = 3.59),
+    beta_peak = 350
+  ),
+  A2 = list(
+    alpha = c(A = 1, a0 = 263, a1 = 4.45),
+    beta = c(A = 0.50, a0 = 176, a1 = 1.52),
+    beta_peak = 368
+  ),
+  A4 = list(
+    alpha = c(A = 1, a0 = 420, a1 = 7.73),
+    beta = c(A = 0.23, a0 = 252, a1 = 2.97),
+    beta_peak = 329
+  )
+)
+
+ssh_band <- function(peak, wlmat, par) {
+  par <- unname(par)
+  x <- log10(wlmat / peak)
+  par[1] * exp(-par[2] * x^2 * (1 + par[3] * x + (3 / 8) * (par[3] * x)^2))
+}
+
+sens_ssh <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") {
+  pars <- ssh_bands[[chromophore]]
+
+  peaks <- ssh_band(peaksens, wlmat, pars$alpha)
+
+  if (beta) {
+    peaks <- peaks + ssh_band(pars$beta_peak, wlmat, pars$beta)
   }
 
   peaks

--- a/R/sensmodel-templates.R
+++ b/R/sensmodel-templates.R
@@ -69,39 +69,50 @@ sens_template <- function(template, peaksens, wlmat, beta) {
 sens_govardovskii <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") {
   x <- peaksens / wlmat
 
+  # A, a, B, b, C, c and D are the symbols of their equation 1, kept as-is so the
+  # implementation can be read against the paper. Only the first pair carries an
+  # interpretation: A and a set the slope and the intercept of the long-wave limb,
+  # which is close to linear when log sensitivity is plotted against x. The rest
+  # shape the peak and the short-wave limb and have no individual meaning, being
+  # a refit of Lamb's (1995) empirical form. They are held in a list so that `c`
+  # does not shadow base::c.
   if (identical(chromophore, "A1")) {
-    A <- 69.7
-    a <- 0.8795 + 0.0459 * exp(-(peaksens - 300)^2 / 11940)
-    B <- 28
-    b <- 0.922
-    Cc <- -14.9
-    cc <- 1.104
-    D <- 0.674
+    pars <- list(
+      A = 69.7,
+      a = 0.8795 + 0.0459 * exp(-(peaksens - 300)^2 / 11940),
+      B = 28,
+      b = 0.922,
+      C = -14.9,
+      c = 1.104,
+      D = 0.674
+    )
 
-    beta_amp <- 0.26
+    beta_amplitude <- 0.26
     beta_peak <- 189 + 0.315 * peaksens
     beta_width <- -40.5 + 0.195 * peaksens
   } else {
-    A <- 62.7 + 1.834 * exp((peaksens - 625) / 54.2)
-    a <- 0.875 + 0.0268 * exp((peaksens - 665) / 40.7)
-    B <- 20.85
-    b <- 0.9101
-    Cc <- -10.37
-    cc <- 1.1123
-    D <- 0.5343
+    pars <- list(
+      A = 62.7 + 1.834 * exp((peaksens - 625) / 54.2),
+      a = 0.875 + 0.0268 * exp((peaksens - 665) / 40.7),
+      B = 20.85,
+      b = 0.9101,
+      C = -10.37,
+      c = 1.1123,
+      D = 0.5343
+    )
 
-    beta_amp <- 0.37
+    beta_amplitude <- 0.37
     beta_peak <- 216.7 + 0.287 * peaksens
     beta_width <- 317 - 1.149 * peaksens + 0.00124 * peaksens^2
   }
 
-  peaks <- 1 / (exp(A * (a - x)) +
-    exp(B * (b - x)) +
-    exp(Cc * (cc - x)) +
-    D)
+  peaks <- 1 / (exp(pars$A * (pars$a - x)) +
+    exp(pars$B * (pars$b - x)) +
+    exp(pars$C * (pars$c - x)) +
+    pars$D)
 
   if (beta) {
-    betabands <- beta_amp * exp(-((wlmat - beta_peak) / beta_width)^2)
+    betabands <- beta_amplitude * exp(-((wlmat - beta_peak) / beta_width)^2)
     peaks <- peaks + betabands
   }
 
@@ -122,8 +133,9 @@ sens_govardovskii <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") 
 #    Fig. 4), restated in Stavenga (2010); the 340 nm in Table 1 is the value
 #    fitted to bovine rhodopsin specifically, not the value used for prediction.
 #    For A2 no prediction value is published, so the Table 1 fit to carp
-#    porphyropsin (368 nm) is used. A fixed beta band distorts the summed curve
-#    for short-wavelength pigments, so sensmodel() checks peak recovery and warns.
+#    porphyropsin (368 nm) is used. A fixed beta band pulls the maximum of the
+#    summed curve away from peaksens for short-wavelength pigments, which is why
+#    the documentation recommends beta = FALSE with these two templates.
 #
 # 2. Table 1 also lists a gamma band for A1 and A4. It is excluded here: it peaks
 #    near 276 nm, outside the default range of sensmodel(), and Govardovskii has
@@ -132,37 +144,49 @@ sens_govardovskii <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") 
 # A4 coefficients are stored but not reachable from sensmodel(), pending a use
 # case. Note this is A4 (Table 1 of the paper), not the more widely encountered
 # A3 chromophore of many insects.
+# `amplitude` is the height of the band relative to the alpha peak, `a0` its
+# width and `a1` its skew towards higher energies; a0 and a1 are the paper's own
+# symbols. The alpha band peaks at the requested peaksens, so only the beta band
+# carries a `peak` of its own.
 ssh_bands <- list(
   A1 = list(
-    alpha = c(A = 1, a0 = 380, a1 = 6.09),
-    beta = c(A = 0.29, a0 = 247, a1 = 3.59),
-    beta_peak = 350
+    alpha = list(amplitude = 1, a0 = 380, a1 = 6.09),
+    beta = list(amplitude = 0.29, a0 = 247, a1 = 3.59, peak = 350)
   ),
   A2 = list(
-    alpha = c(A = 1, a0 = 263, a1 = 4.45),
-    beta = c(A = 0.50, a0 = 176, a1 = 1.52),
-    beta_peak = 368
+    alpha = list(amplitude = 1, a0 = 263, a1 = 4.45),
+    beta = list(amplitude = 0.50, a0 = 176, a1 = 1.52, peak = 368)
   ),
   A4 = list(
-    alpha = c(A = 1, a0 = 420, a1 = 7.73),
-    beta = c(A = 0.23, a0 = 252, a1 = 2.97),
-    beta_peak = 329
+    alpha = list(amplitude = 1, a0 = 420, a1 = 7.73),
+    beta = list(amplitude = 0.23, a0 = 252, a1 = 2.97, peak = 329)
   )
 )
 
-ssh_band <- function(peak, wlmat, par) {
-  par <- unname(par)
+ssh_band <- function(wlmat, peak, amplitude, a0, a1) {
   x <- log10(wlmat / peak)
-  par[1] * exp(-par[2] * x^2 * (1 + par[3] * x + (3 / 8) * (par[3] * x)^2))
+  amplitude * exp(-a0 * x^2 * (1 + a1 * x + (3 / 8) * (a1 * x)^2))
 }
 
 sens_ssh <- function(peaksens, wlmat, beta = TRUE, chromophore = "A1") {
   pars <- ssh_bands[[chromophore]]
 
-  peaks <- ssh_band(peaksens, wlmat, pars$alpha)
+  peaks <- ssh_band(
+    wlmat,
+    peak = peaksens,
+    amplitude = pars$alpha$amplitude,
+    a0 = pars$alpha$a0,
+    a1 = pars$alpha$a1
+  )
 
   if (beta) {
-    peaks <- peaks + ssh_band(pars$beta_peak, wlmat, pars$beta)
+    peaks <- peaks + ssh_band(
+      wlmat,
+      peak = pars$beta$peak,
+      amplitude = pars$beta$amplitude,
+      a0 = pars$beta$a0,
+      a1 = pars$beta$a1
+    )
   }
 
   peaks

--- a/R/sensmodel.R
+++ b/R/sensmodel.R
@@ -35,7 +35,7 @@
 #'   author and the chromophore are named, since a template's shape depends on
 #'   both. One of:
 #'   * `"govardovskii_a1"` (default): Govardovskii et al. (2000), vitamin A1
-#'     chromophore (rhodopsin). The most widely used template, and previously 
+#'     chromophore (rhodopsin). The most widely used template, and previously
 #'     the only implemented option.
 #'   * `"govardovskii_a2"`: Govardovskii et al. (2000), vitamin A2 chromophore
 #'     (porphyropsin), found in freshwater fish, amphibians, and species that

--- a/R/sensmodel.R
+++ b/R/sensmodel.R
@@ -37,26 +37,32 @@
 #'   * `"govardovskii_a1"` (default): Govardovskii et al. (2000), vitamin A1
 #'     chromophore (rhodopsin). The most widely used template, and previously 
 #'     the only implemented option.
+#'   * `"govardovskii_a2"`: Govardovskii et al. (2000), vitamin A2 chromophore
+#'     (porphyropsin), found in freshwater fish, amphibians, and species that
+#'     switch chromophore seasonally. Fitted to microspectrophotometric data from
+#'     pigments peaking between roughly 440 and 620 nm. The recommended choice for
+#'     A2 pigments, and the one to pair with the default when comparing
+#'     chromophores, since staying within one template family avoids confounding
+#'     chromophore with template.
 #'   * `"ssh_a1"`: Stavenga, Smits and Hoenders (1993), vitamin A1. Differs from
 #'     `"govardovskii_a1"` by only a few percent above 450 nm, but diverges in the
 #'     ultraviolet, where Stavenga (2010) judges both to be unreliable.
-#'   * `"ssh_a2"`: Stavenga, Smits and Hoenders (1993), vitamin A2 chromophore
-#'     (porphyropsin), found in freshwater fish, amphibians, and species that
-#'     switch chromophore seasonally. At a given `peaksens` an A2 band is around
-#'     19% broader than the A1 equivalent, so a porphyropsin pigment is not
-#'     recovered by shifting `peaksens` alone.
+#'   * `"ssh_a2"`: Stavenga, Smits and Hoenders (1993), vitamin A2, calibrated on
+#'     carp porphyropsin alone.
 #'
-#'  
-#'    `beta = FALSE` is recommended with either SSH template. Their beta band has
+#'   At a given `peaksens` an A2 band is substantially broader than the A1
+#'   equivalent, so a porphyropsin pigment is not recovered by shifting `peaksens`
+#'   alone.
+#'
+#'   `beta = FALSE` is recommended with either SSH template. Their beta band has
 #'   a fixed peak wavelength, rather than one that scales with `peaksens` as
 #'   Govardovskii's does, so for short-wavelength pigments it pulls the maximum of
 #'   the summed curve away from the `peaksens` that was asked for (by up to 8 nm
 #'   for `"ssh_a1"` between 388 and 402 nm, and by more than 5 nm for `"ssh_a2"`
 #'   anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
 #'   a known shortcoming of the template, the beta peak being correlated with the
-#'   alpha peak in practice. The A2 template is calibrated on carp porphyropsin, and
-#'   A2 pigments are generally long-wavelength, so short-wavelength A2 requests
-#'   sit outside its validated range in any case.
+#'   alpha peak in practice. Both Govardovskii beta bands scale with `peaksens`
+#'   and do not have this problem.
 #'
 #' @return A data frame of class `rspec` containing each cone model as a column.
 #'
@@ -98,7 +104,7 @@
 
 sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NULL,
                       oiltype = NULL, beta = TRUE, om = NULL, integrate = TRUE, sensnames = paste0("lmax", peaksens),
-                      template = c("govardovskii_a1", "ssh_a1", "ssh_a2")) {
+                      template = c("govardovskii_a1", "govardovskii_a2", "ssh_a1", "ssh_a2")) {
   template <- match.arg(template)
 
   if (!is.null(lambdacut)) {

--- a/R/sensmodel.R
+++ b/R/sensmodel.R
@@ -31,6 +31,32 @@
 #' @param sensnames A vector equal in length to `peaksens`, specifying custom
 #'   names for the resulting sensitivity curves (e.g. c('s', 'm', 'l') for
 #'   short-, medium- and long-wavelength sensitive receptors.)
+#' @param template the pigment template used to generate the curves. Both the
+#'   author and the chromophore are named, since a template's shape depends on
+#'   both. One of:
+#'   * `"govardovskii_a1"` (default): Govardovskii et al. (2000), vitamin A1
+#'     chromophore (rhodopsin). The most widely used template, and previously 
+#'     the only implemented option.
+#'   * `"ssh_a1"`: Stavenga, Smits and Hoenders (1993), vitamin A1. Differs from
+#'     `"govardovskii_a1"` by only a few percent above 450 nm, but diverges in the
+#'     ultraviolet, where Stavenga (2010) judges both to be unreliable.
+#'   * `"ssh_a2"`: Stavenga, Smits and Hoenders (1993), vitamin A2 chromophore
+#'     (porphyropsin), found in freshwater fish, amphibians, and species that
+#'     switch chromophore seasonally. At a given `peaksens` an A2 band is around
+#'     19% broader than the A1 equivalent, so a porphyropsin pigment is not
+#'     recovered by shifting `peaksens` alone.
+#'
+#'  
+#'    `beta = FALSE` is recommended with either SSH template. Their beta band has
+#'   a fixed peak wavelength, rather than one that scales with `peaksens` as
+#'   Govardovskii's does, so for short-wavelength pigments it pulls the maximum of
+#'   the summed curve away from the `peaksens` that was asked for (by up to 8 nm
+#'   for `"ssh_a1"` between 388 and 402 nm, and by more than 5 nm for `"ssh_a2"`
+#'   anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
+#'   a known shortcoming of the template, the beta peak being correlated with the
+#'   alpha peak in practice. The A2 template is calibrated on carp porphyropsin, and
+#'   A2 pigments are generally long-wavelength, so short-wavelength A2 requests
+#'   sit outside its validated range in any case.
 #'
 #' @return A data frame of class `rspec` containing each cone model as a column.
 #'
@@ -56,6 +82,12 @@
 #' @references Hart NS, and Vorobyev M. 2005. Modeling oil droplet absorption
 #'   spectra and spectral sensitivities of bird cone photoreceptors. Journal of
 #'   Comparative Physiology A. 191: 381-392, \doi{10.1007/s00359-004-0595-3}
+#' @references Stavenga DG, Smits RP, Hoenders BJ. 1993. Simple exponential
+#'   functions describing the absorbance bands of visual pigment spectra. Vision
+#'   Research 33:1011-1017, \doi{10.1016/0042-6989(93)90237-Q}
+#' @references Stavenga DG. 2010. On visual pigment templates and the spectral
+#'   shape of invertebrate rhodopsins and metarhodopsins. Journal of Comparative
+#'   Physiology A 196:869-878, \doi{10.1007/s00359-010-0568-7}
 #' @references Hart NS, Partridge JC, Cuthill IC, Bennett AT (2000) Visual
 #'   pigments, oil droplets, ocular media and cone photoreceptor distribution in
 #'   two species of passerine bird: the blue tit (*Parus caeruleus* L.) and the
@@ -65,7 +97,10 @@
 
 
 sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NULL,
-                      oiltype = NULL, beta = TRUE, om = NULL, integrate = TRUE, sensnames = paste0("lmax", peaksens)) {
+                      oiltype = NULL, beta = TRUE, om = NULL, integrate = TRUE, sensnames = paste0("lmax", peaksens),
+                      template = c("govardovskii_a1", "ssh_a1", "ssh_a2")) {
+  template <- match.arg(template)
+
   if (!is.null(lambdacut)) {
     if (is.null(Bmid) && is.null(oiltype)) stop("Bmid or oiltype must be included when including a lambdacut vector", call. = FALSE)
     if (length(lambdacut) != length(peaksens)) stop("lambdacut must be same length as peaksens", call. = FALSE)
@@ -91,8 +126,15 @@ sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NU
 
   # Pigment absorbance. See R/sensmodel-templates.R for the calling contract.
   # Everything below this point is template-agnostic.
-  peaks <- sens_govardovskii(peaksens, sensecurves, beta = beta)
+  peaks <- sens_template(template, peaksens, sensecurves, beta = beta)
 
+  # Note that summing an alpha and a beta band can put the maximum of the result
+  # a little away from the requested peak sensitivity. This is slight for
+  # Govardovskii, whose beta band tracks peaksens, but the SSH beta band sits at
+  # a fixed wavelength and so shifts the peak of short-wavelength pigments by
+  # several nm. That is a property of the published template rather than an
+  # error, and is documented under the `template` argument along with the
+  # recommendation to use beta = FALSE.
   peaks <- peaks / apply(peaks, 1, max)
 
   if (!is.null(lambdacut) && !is.null(Bmid)) {
@@ -158,6 +200,8 @@ sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NU
   } else {
     attr(sensecurves, "om") <- TRUE
   }
+
+  attr(sensecurves, "template") <- template
 
   sensecurves
 }

--- a/R/sensmodel.R
+++ b/R/sensmodel.R
@@ -148,9 +148,9 @@ sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NU
     if (any(off)) {
       warning(
         "the SSH beta band has a fixed peak wavelength, and for ",
-        paste(peaksens[off], collapse = ", "),
+        toString(peaksens[off]),
         " nm it shifts the maximum of the modelled curve to ",
-        paste(realised[off], collapse = ", "),
+        toString(realised[off]),
         " nm. Consider beta = FALSE, or one of the Govardovskii templates, ",
         "whose beta band scales with peaksens.",
         call. = FALSE

--- a/R/sensmodel.R
+++ b/R/sensmodel.R
@@ -59,10 +59,11 @@
 #'   Govardovskii's does, so for short-wavelength pigments it pulls the maximum of
 #'   the summed curve away from the `peaksens` that was asked for (by up to 8 nm
 #'   for `"ssh_a1"` between 388 and 402 nm, and by more than 5 nm for `"ssh_a2"`
-#'   anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
-#'   a known shortcoming of the template, the beta peak being correlated with the
-#'   alpha peak in practice. Both Govardovskii beta bands scale with `peaksens`
-#'   and do not have this problem.
+#'   anywhere below about 475 nm), and a warning is given wherever the shift
+#'   exceeds 5 nm. Stavenga (2010) notes that a fixed beta peak is a known
+#'   shortcoming of the template, the beta peak being correlated with the alpha
+#'   peak in practice. Both Govardovskii beta bands scale with `peaksens` and do
+#'   not have this problem.
 #'
 #' @return A data frame of class `rspec` containing each cone model as a column.
 #'
@@ -134,13 +135,29 @@ sensmodel <- function(peaksens, range = c(300, 700), lambdacut = NULL, Bmid = NU
   # Everything below this point is template-agnostic.
   peaks <- sens_template(template, peaksens, sensecurves, beta = beta)
 
-  # Note that summing an alpha and a beta band can put the maximum of the result
-  # a little away from the requested peak sensitivity. This is slight for
-  # Govardovskii, whose beta band tracks peaksens, but the SSH beta band sits at
-  # a fixed wavelength and so shifts the peak of short-wavelength pigments by
-  # several nm. That is a property of the published template rather than an
-  # error, and is documented under the `template` argument along with the
-  # recommendation to use beta = FALSE.
+  # Summing an alpha and a beta band can put the maximum of the result away from
+  # the requested peak sensitivity. The check is deliberately scoped to the SSH
+  # templates, whose beta band sits at a fixed wavelength: Govardovskii's tracks
+  # peaksens and shifts the peak by at most a couple of nm across the range it
+  # was fitted over, but it does exceed 5 nm for A1 pigments peaking near 320 nm,
+  # and warning there would be a behaviour change for existing users of the
+  # default template rather than a caveat about a newly added one.
+  if (beta && startsWith(template, "ssh")) {
+    realised <- wl[max.col(peaks, ties.method = "first")]
+    off <- abs(realised - peaksens) > 5
+    if (any(off)) {
+      warning(
+        "the SSH beta band has a fixed peak wavelength, and for ",
+        paste(peaksens[off], collapse = ", "),
+        " nm it shifts the maximum of the modelled curve to ",
+        paste(realised[off], collapse = ", "),
+        " nm. Consider beta = FALSE, or one of the Govardovskii templates, ",
+        "whose beta band scales with peaksens.",
+        call. = FALSE
+      )
+    }
+  }
+
   peaks <- peaks / apply(peaks, 1, max)
 
   if (!is.null(lambdacut) && !is.null(Bmid)) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -53,6 +53,7 @@ Habronattus
 Hadfield
 Hemmings
 Herberstein
+Hoenders
 Horak
 Icterus
 Incl
@@ -119,6 +120,7 @@ Sicalis
 Siefferman
 Smiseth
 SpectraSuite
+Stavenga
 Sturnus
 Taeniopygia
 Tetrachromacy
@@ -160,6 +162,7 @@ cbind
 center
 centered
 centers
+chromophore
 cie
 cieLAB
 cielab
@@ -262,6 +265,7 @@ peaksens
 peakshape
 photopigments
 png
+porphyropsin
 pos
 procspec
 projplot
@@ -271,6 +275,7 @@ qcatch
 reflectances
 rgb
 rgl
+rhodopsin
 rimg
 rm
 rspec

--- a/man/adjacent.Rd
+++ b/man/adjacent.Rd
@@ -122,11 +122,26 @@ boundary-strength (Endler et al. 2018) analyses, along with overall pattern
 contrast (Endler & Mielke 2005).
 }
 \details{
+\subsection{Parallel processing}{
+
 You can customise the type of parallel processing used by this function with
 the \code{\link[future:plan]{future::plan()}} function. This works on all operating systems, as well
 as high performance computing (HPC) environment. Similarly, you can customise
 the way progress is shown with the \code{\link[progressr:handlers]{progressr::handlers()}} functions
 (progress bar, acoustic feedback, nothing, etc.)
+}
+
+\subsection{Custom parsers}{
+
+To create a custom parser to pass to the \code{parser} argument, you need to create
+with the following signature:
+\itemize{
+\item input: a file path (string) as a first argument, and optionally, any
+additional arguments needed to parse the file. These arguments can be passed
+to the \code{lr_get_spec()} function via the \code{...} argument.
+\item output: a named list of two elements, as defined in \code{lr_parse_generic()}.
+}
+}
 }
 \examples{
 \donttest{

--- a/man/bootcoldist.Rd
+++ b/man/bootcoldist.Rd
@@ -78,11 +78,26 @@ Uses a bootstrap procedure to generate confidence intervals
 for the mean colour distance between two or more samples of colours
 }
 \details{
+\subsection{Parallel processing}{
+
 You can customise the type of parallel processing used by this function with
 the \code{\link[future:plan]{future::plan()}} function. This works on all operating systems, as well
 as high performance computing (HPC) environment. Similarly, you can customise
 the way progress is shown with the \code{\link[progressr:handlers]{progressr::handlers()}} functions
 (progress bar, acoustic feedback, nothing, etc.)
+}
+
+\subsection{Custom parsers}{
+
+To create a custom parser to pass to the \code{parser} argument, you need to create
+with the following signature:
+\itemize{
+\item input: a file path (string) as a first argument, and optionally, any
+additional arguments needed to parse the file. These arguments can be passed
+to the \code{lr_get_spec()} function via the \code{...} argument.
+\item output: a named list of two elements, as defined in \code{lr_parse_generic()}.
+}
+}
 }
 \examples{
 \donttest{

--- a/man/classify.Rd
+++ b/man/classify.Rd
@@ -60,11 +60,26 @@ cluster centres (i.e. colour classes) are stored as object attributes.
 Classify image pixels into discrete colour classes.
 }
 \details{
+\subsection{Parallel processing}{
+
 You can customise the type of parallel processing used by this function with
 the \code{\link[future:plan]{future::plan()}} function. This works on all operating systems, as well
 as high performance computing (HPC) environment. Similarly, you can customise
 the way progress is shown with the \code{\link[progressr:handlers]{progressr::handlers()}} functions
 (progress bar, acoustic feedback, nothing, etc.)
+}
+
+\subsection{Custom parsers}{
+
+To create a custom parser to pass to the \code{parser} argument, you need to create
+with the following signature:
+\itemize{
+\item input: a file path (string) as a first argument, and optionally, any
+additional arguments needed to parse the file. These arguments can be passed
+to the \code{lr_get_spec()} function via the \code{...} argument.
+\item output: a named list of two elements, as defined in \code{lr_parse_generic()}.
+}
+}
 }
 \note{
 Since the \code{kmeans} process draws on random numbers to find initial

--- a/man/getspec.Rd
+++ b/man/getspec.Rd
@@ -53,11 +53,26 @@ USB4000 and Jaz spectrometers), CRAIC software (after exporting) and
 Avantes (before or after exporting).
 }
 \details{
+\subsection{Parallel processing}{
+
 You can customise the type of parallel processing used by this function with
 the \code{\link[future:plan]{future::plan()}} function. This works on all operating systems, as well
 as high performance computing (HPC) environment. Similarly, you can customise
 the way progress is shown with the \code{\link[progressr:handlers]{progressr::handlers()}} functions
 (progress bar, acoustic feedback, nothing, etc.)
+}
+
+\subsection{Custom parsers}{
+
+To create a custom parser to pass to the \code{parser} argument, you need to create
+with the following signature:
+\itemize{
+\item input: a file path (string) as a first argument, and optionally, any
+additional arguments needed to parse the file. These arguments can be passed
+to the \code{lr_get_spec()} function via the \code{...} argument.
+\item output: a named list of two elements, as defined in \code{lr_parse_generic()}.
+}
+}
 }
 \examples{
 # Import and inspect example spectral data with a range of set to 400-700nm.

--- a/man/sensmodel.Rd
+++ b/man/sensmodel.Rd
@@ -13,7 +13,8 @@ sensmodel(
   beta = TRUE,
   om = NULL,
   integrate = TRUE,
-  sensnames = paste0("lmax", peaksens)
+  sensnames = paste0("lmax", peaksens),
+  template = c("govardovskii_a1", "ssh_a1", "ssh_a2")
 )
 }
 \arguments{
@@ -52,6 +53,34 @@ are considered, for compatibility with visual model procedures.}
 \item{sensnames}{A vector equal in length to \code{peaksens}, specifying custom
 names for the resulting sensitivity curves (e.g. c('s', 'm', 'l') for
 short-, medium- and long-wavelength sensitive receptors.)}
+
+\item{template}{the pigment template used to generate the curves. Both the
+author and the chromophore are named, since a template's shape depends on
+both. One of:
+\itemize{
+\item \code{"govardovskii_a1"} (default): Govardovskii et al. (2000), vitamin A1
+chromophore (rhodopsin). The most widely used template, and previously
+the only implemented option.
+\item \code{"ssh_a1"}: Stavenga, Smits and Hoenders (1993), vitamin A1. Differs from
+\code{"govardovskii_a1"} by only a few percent above 450 nm, but diverges in the
+ultraviolet, where Stavenga (2010) judges both to be unreliable.
+\item \code{"ssh_a2"}: Stavenga, Smits and Hoenders (1993), vitamin A2 chromophore
+(porphyropsin), found in freshwater fish, amphibians, and species that
+switch chromophore seasonally. At a given \code{peaksens} an A2 band is around
+19\% broader than the A1 equivalent, so a porphyropsin pigment is not
+recovered by shifting \code{peaksens} alone.
+}
+
+\code{beta = FALSE} is recommended with either SSH template. Their beta band has
+a fixed peak wavelength, rather than one that scales with \code{peaksens} as
+Govardovskii's does, so for short-wavelength pigments it pulls the maximum of
+the summed curve away from the \code{peaksens} that was asked for (by up to 8 nm
+for \code{"ssh_a1"} between 388 and 402 nm, and by more than 5 nm for \code{"ssh_a2"}
+anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
+a known shortcoming of the template, the beta peak being correlated with the
+alpha peak in practice. The A2 template is calibrated on carp porphyropsin, and
+A2 pigments are generally long-wavelength, so short-wavelength A2 requests
+sit outside its validated range in any case.}
 }
 \value{
 A data frame of class \code{rspec} containing each cone model as a column.
@@ -81,6 +110,14 @@ Govardovskii VI, Fyhrquist N, Reuter T, Kuzmin DG and Donner K.
 Hart NS, and Vorobyev M. 2005. Modeling oil droplet absorption
 spectra and spectral sensitivities of bird cone photoreceptors. Journal of
 Comparative Physiology A. 191: 381-392, \doi{10.1007/s00359-004-0595-3}
+
+Stavenga DG, Smits RP, Hoenders BJ. 1993. Simple exponential
+functions describing the absorbance bands of visual pigment spectra. Vision
+Research 33:1011-1017, \doi{10.1016/0042-6989(93)90237-Q}
+
+Stavenga DG. 2010. On visual pigment templates and the spectral
+shape of invertebrate rhodopsins and metarhodopsins. Journal of Comparative
+Physiology A 196:869-878, \doi{10.1007/s00359-010-0568-7}
 
 Hart NS, Partridge JC, Cuthill IC, Bennett AT (2000) Visual
 pigments, oil droplets, ocular media and cone photoreceptor distribution in

--- a/man/sensmodel.Rd
+++ b/man/sensmodel.Rd
@@ -14,7 +14,7 @@ sensmodel(
   om = NULL,
   integrate = TRUE,
   sensnames = paste0("lmax", peaksens),
-  template = c("govardovskii_a1", "ssh_a1", "ssh_a2")
+  template = c("govardovskii_a1", "govardovskii_a2", "ssh_a1", "ssh_a2")
 )
 }
 \arguments{
@@ -61,15 +61,23 @@ both. One of:
 \item \code{"govardovskii_a1"} (default): Govardovskii et al. (2000), vitamin A1
 chromophore (rhodopsin). The most widely used template, and previously
 the only implemented option.
+\item \code{"govardovskii_a2"}: Govardovskii et al. (2000), vitamin A2 chromophore
+(porphyropsin), found in freshwater fish, amphibians, and species that
+switch chromophore seasonally. Fitted to microspectrophotometric data from
+pigments peaking between roughly 440 and 620 nm. The recommended choice for
+A2 pigments, and the one to pair with the default when comparing
+chromophores, since staying within one template family avoids confounding
+chromophore with template.
 \item \code{"ssh_a1"}: Stavenga, Smits and Hoenders (1993), vitamin A1. Differs from
 \code{"govardovskii_a1"} by only a few percent above 450 nm, but diverges in the
 ultraviolet, where Stavenga (2010) judges both to be unreliable.
-\item \code{"ssh_a2"}: Stavenga, Smits and Hoenders (1993), vitamin A2 chromophore
-(porphyropsin), found in freshwater fish, amphibians, and species that
-switch chromophore seasonally. At a given \code{peaksens} an A2 band is around
-19\% broader than the A1 equivalent, so a porphyropsin pigment is not
-recovered by shifting \code{peaksens} alone.
+\item \code{"ssh_a2"}: Stavenga, Smits and Hoenders (1993), vitamin A2, calibrated on
+carp porphyropsin alone.
 }
+
+At a given \code{peaksens} an A2 band is substantially broader than the A1
+equivalent, so a porphyropsin pigment is not recovered by shifting \code{peaksens}
+alone.
 
 \code{beta = FALSE} is recommended with either SSH template. Their beta band has
 a fixed peak wavelength, rather than one that scales with \code{peaksens} as
@@ -78,9 +86,8 @@ the summed curve away from the \code{peaksens} that was asked for (by up to 8 nm
 for \code{"ssh_a1"} between 388 and 402 nm, and by more than 5 nm for \code{"ssh_a2"}
 anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
 a known shortcoming of the template, the beta peak being correlated with the
-alpha peak in practice. The A2 template is calibrated on carp porphyropsin, and
-A2 pigments are generally long-wavelength, so short-wavelength A2 requests
-sit outside its validated range in any case.}
+alpha peak in practice. Both Govardovskii beta bands scale with \code{peaksens}
+and do not have this problem.}
 }
 \value{
 A data frame of class \code{rspec} containing each cone model as a column.

--- a/man/sensmodel.Rd
+++ b/man/sensmodel.Rd
@@ -84,10 +84,11 @@ a fixed peak wavelength, rather than one that scales with \code{peaksens} as
 Govardovskii's does, so for short-wavelength pigments it pulls the maximum of
 the summed curve away from the \code{peaksens} that was asked for (by up to 8 nm
 for \code{"ssh_a1"} between 388 and 402 nm, and by more than 5 nm for \code{"ssh_a2"}
-anywhere below about 475 nm). Stavenga (2010) notes that a fixed beta peak is
-a known shortcoming of the template, the beta peak being correlated with the
-alpha peak in practice. Both Govardovskii beta bands scale with \code{peaksens}
-and do not have this problem.}
+anywhere below about 475 nm), and a warning is given wherever the shift
+exceeds 5 nm. Stavenga (2010) notes that a fixed beta peak is a known
+shortcoming of the template, the beta peak being correlated with the alpha
+peak in practice. Both Govardovskii beta bands scale with \code{peaksens} and do
+not have this problem.}
 }
 \value{
 A data frame of class \code{rspec} containing each cone model as a column.

--- a/tests/testthat/_snaps/sensmodel.md
+++ b/tests/testthat/_snaps/sensmodel.md
@@ -22,6 +22,11 @@
           "type": "logical",
           "attributes": {},
           "value": [false]
+        },
+        "template": {
+          "type": "character",
+          "attributes": {},
+          "value": ["govardovskii_a1"]
         }
       },
       "value": [
@@ -72,6 +77,11 @@
           "type": "logical",
           "attributes": {},
           "value": [true]
+        },
+        "template": {
+          "type": "character",
+          "attributes": {},
+          "value": ["govardovskii_a1"]
         }
       },
       "value": [
@@ -122,6 +132,11 @@
           "type": "logical",
           "attributes": {},
           "value": [false]
+        },
+        "template": {
+          "type": "character",
+          "attributes": {},
+          "value": ["govardovskii_a1"]
         }
       },
       "value": [

--- a/tests/testthat/test-sensmodel.R
+++ b/tests/testthat/test-sensmodel.R
@@ -38,12 +38,12 @@ test_that("sensmodel() curves do not depend on range", {
   # Raising the lower bound
   full <- sensmodel(c(450, 500, 560), range = c(300, 700), integrate = FALSE)
   raised <- sensmodel(c(450, 500, 560), range = c(400, 700), integrate = FALSE)
-  expect_equal(sens_cols(full, 400), sens_cols(raised, 400))
+  expect_identical(sens_cols(full, 400), sens_cols(raised, 400))
 
   # Lowering it, which affects UV pigments in the other direction
   lowered <- sensmodel(c(360, 450, 560), range = c(250, 700), integrate = FALSE)
   base <- sensmodel(c(360, 450, 560), range = c(300, 700), integrate = FALSE)
-  expect_equal(sens_cols(lowered, 300), sens_cols(base, 300))
+  expect_identical(sens_cols(lowered, 300), sens_cols(base, 300))
 })
 
 test_that("sensmodel() templates", {
@@ -51,11 +51,11 @@ test_that("sensmodel() templates", {
   for (tmpl in c("govardovskii_a1", "govardovskii_a2", "ssh_a1", "ssh_a2")) {
     s <- sensmodel(c(400, 500, 600), template = tmpl, beta = FALSE, integrate = FALSE)
     peaks <- s$wl[apply(s[-1], 2, which.max)]
-    expect_equal(peaks, c(400, 500, 600), info = tmpl)
+    expect_identical(peaks, c(400L, 500L, 600L), info = tmpl)
   }
 
   # Default is unchanged, and is the Govardovskii A1 template
-  expect_equal(
+  expect_identical(
     sensmodel(c(400, 500)),
     sensmodel(c(400, 500), template = "govardovskii_a1")
   )
@@ -121,16 +121,15 @@ test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigment
   expect_lt(realised(395, template = "ssh_a1"), 395 - 5)
 
   # The alpha band alone recovers peaksens exactly, and the default template is
-  # unaffected at the same peak sensitivities. expect_equal rather than
-  # expect_identical because wl is an integer sequence, and the type is beside
-  # the point here.
-  expect_equal(realised(430, template = "ssh_a2", beta = FALSE), 430)
-  expect_equal(realised(395, template = "ssh_a1", beta = FALSE), 395)
-  expect_equal(realised(430, template = "govardovskii_a1"), 430)
+  # unaffected at the same peak sensitivities. Integer literals because wl is an
+  # integer sequence.
+  expect_identical(realised(430, template = "ssh_a2", beta = FALSE), 430L)
+  expect_identical(realised(395, template = "ssh_a1", beta = FALSE), 395L)
+  expect_identical(realised(430, template = "govardovskii_a1"), 430L)
 
   # Long-wavelength pigments, where the fixed beta band is far from the alpha
   # band, are unaffected
-  expect_equal(realised(600, template = "ssh_a2"), 600)
+  expect_identical(realised(600, template = "ssh_a2"), 600L)
 
   # Govardovskii's A2 beta band scales with peaksens, so unlike ssh_a2 it stays
   # within a couple of nm across the range it was fitted over. This is the reason

--- a/tests/testthat/test-sensmodel.R
+++ b/tests/testthat/test-sensmodel.R
@@ -46,6 +46,85 @@ test_that("sensmodel() curves do not depend on range", {
   expect_equal(sens_cols(lowered, 300), sens_cols(base, 300))
 })
 
+test_that("sensmodel() templates", {
+  # Alpha bands peak where they were asked to, for every template
+  for (tmpl in c("govardovskii_a1", "ssh_a1", "ssh_a2")) {
+    s <- sensmodel(c(400, 500, 600), template = tmpl, beta = FALSE, integrate = FALSE)
+    peaks <- s$wl[apply(s[-1], 2, which.max)]
+    expect_equal(peaks, c(400, 500, 600), info = tmpl)
+  }
+
+  # Default is unchanged, and is the Govardovskii A1 template
+  expect_equal(
+    sensmodel(c(400, 500)),
+    sensmodel(c(400, 500), template = "govardovskii_a1")
+  )
+  # 600 nm rather than 400 nm for the SSH templates: 400 nm sits inside the
+  # window where the fixed beta band moves the peak, and these are checking the
+  # attribute rather than that warning
+  expect_identical(attr(sensmodel(400), "template"), "govardovskii_a1")
+  expect_identical(attr(sensmodel(600, template = "ssh_a2"), "template"), "ssh_a2")
+
+  # Unambiguous abbreviations resolve, as match.arg intends, but one that could
+  # mean either SSH chromophore is rejected rather than silently picking A1
+  expect_identical(attr(sensmodel(400, template = "govardovskii"), "template"), "govardovskii_a1")
+  expect_identical(attr(sensmodel(600, template = "ssh_a1"), "template"), "ssh_a1")
+  expect_error(sensmodel(400, template = "ssh"), "should be one of")
+
+  # A2 is not A1 shifted: at matched peaksens the band is markedly broader.
+  # Stavenga et al. (1993) Table 1 gives a0 = 263 for A2 against 380 for A1.
+  hbw <- function(x) {
+    above <- x$wl[x[[2]] >= 0.5]
+    max(above) - min(above)
+  }
+  for (lmax in c(500, 550, 600)) {
+    ratio <- hbw(sensmodel(lmax, template = "ssh_a2", beta = FALSE, integrate = FALSE)) /
+      hbw(sensmodel(lmax, template = "ssh_a1", beta = FALSE, integrate = FALSE))
+    expect_gt(ratio, 1.15)
+    expect_lt(ratio, 1.25)
+  }
+
+  # Stavenga (2010) reports the Govardovskii and SSH alpha bands to be close for
+  # peaksens above 400 nm, and to diverge in the ultraviolet
+  dev <- function(lmax) {
+    a <- sensmodel(lmax, template = "govardovskii_a1", beta = FALSE, integrate = FALSE)
+    b <- sensmodel(lmax, template = "ssh_a1", beta = FALSE, integrate = FALSE)
+    max(abs(a[[2]] - b[[2]]))
+  }
+  expect_lt(dev(500), 0.05)
+  expect_lt(dev(600), 0.05)
+  expect_gt(dev(360), 0.10)
+})
+
+test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigments", {
+  # The SSH beta band sits at a fixed wavelength rather than scaling with
+  # peaksens, so summing it with the alpha band moves the maximum of the result.
+  # This is a property of the published template, not an error, which is why
+  # beta = FALSE is the documented recommendation rather than a warning. The test
+  # exists so that anyone changing the beta band notices they have done so.
+  realised <- function(...) {
+    s <- sensmodel(..., integrate = FALSE)
+    s$wl[which.max(s[[2]])]
+  }
+
+  expect_lt(realised(430, template = "ssh_a2"), 430 - 5)
+  expect_lt(realised(395, template = "ssh_a1"), 395 - 5)
+
+  # The alpha band alone recovers peaksens exactly, and the default template is
+  # unaffected at the same peak sensitivities
+  expect_identical(realised(430, template = "ssh_a2", beta = FALSE), 430)
+  expect_identical(realised(395, template = "ssh_a1", beta = FALSE), 395)
+  expect_identical(realised(430, template = "govardovskii_a1"), 430)
+
+  # Long-wavelength pigments, where the fixed beta band is far from the alpha
+  # band, are unaffected
+  expect_identical(realised(600, template = "ssh_a2"), 600)
+
+  # None of this warns
+  expect_silent(sensmodel(430, template = "ssh_a2"))
+  expect_silent(sensmodel(395, template = "ssh_a1"))
+})
+
 test_that("sensmodel() errors", {
   expect_error(sensmodel(c(300, 400, 500), lambdacut = 400), "must be included")
   expect_error(sensmodel(c(300, 400, 500), lambdacut = 400, Bmid = 450), "length")

--- a/tests/testthat/test-sensmodel.R
+++ b/tests/testthat/test-sensmodel.R
@@ -48,7 +48,7 @@ test_that("sensmodel() curves do not depend on range", {
 
 test_that("sensmodel() templates", {
   # Alpha bands peak where they were asked to, for every template
-  for (tmpl in c("govardovskii_a1", "ssh_a1", "ssh_a2")) {
+  for (tmpl in c("govardovskii_a1", "govardovskii_a2", "ssh_a1", "ssh_a2")) {
     s <- sensmodel(c(400, 500, 600), template = tmpl, beta = FALSE, integrate = FALSE)
     peaks <- s$wl[apply(s[-1], 2, which.max)]
     expect_equal(peaks, c(400, 500, 600), info = tmpl)
@@ -65,35 +65,45 @@ test_that("sensmodel() templates", {
   expect_identical(attr(sensmodel(400), "template"), "govardovskii_a1")
   expect_identical(attr(sensmodel(600, template = "ssh_a2"), "template"), "ssh_a2")
 
-  # Unambiguous abbreviations resolve, as match.arg intends, but one that could
-  # mean either SSH chromophore is rejected rather than silently picking A1
-  expect_identical(attr(sensmodel(400, template = "govardovskii"), "template"), "govardovskii_a1")
   expect_identical(attr(sensmodel(600, template = "ssh_a1"), "template"), "ssh_a1")
-  expect_error(sensmodel(400, template = "ssh"), "should be one of")
 
-  # A2 is not A1 shifted: at matched peaksens the band is markedly broader.
-  # Stavenga et al. (1993) Table 1 gives a0 = 263 for A2 against 380 for A1.
+  # Naming both author and chromophore means no abbreviation is unique, which is
+  # the intended trade: an ambiguous template is rejected rather than silently
+  # resolved to one chromophore
+  expect_error(sensmodel(400, template = "ssh"), "should be one of")
+  expect_error(sensmodel(400, template = "govardovskii"), "should be one of")
+
+  # A2 is not A1 shifted: at matched peaksens the band is markedly broader. Both
+  # template families agree on this independently, Govardovskii et al. (2000)
+  # from a broad MSP sample and Stavenga et al. (1993) from carp porphyropsin.
   hbw <- function(x) {
     above <- x$wl[x[[2]] >= 0.5]
     max(above) - min(above)
   }
+  band <- function(...) hbw(sensmodel(..., beta = FALSE, integrate = FALSE))
   for (lmax in c(500, 550, 600)) {
-    ratio <- hbw(sensmodel(lmax, template = "ssh_a2", beta = FALSE, integrate = FALSE)) /
-      hbw(sensmodel(lmax, template = "ssh_a1", beta = FALSE, integrate = FALSE))
-    expect_gt(ratio, 1.15)
-    expect_lt(ratio, 1.25)
+    expect_gt(band(lmax, template = "ssh_a2") / band(lmax, template = "ssh_a1"), 1.15)
+    expect_lt(band(lmax, template = "ssh_a2") / band(lmax, template = "ssh_a1"), 1.25)
+    expect_gt(band(lmax, template = "govardovskii_a2") / band(lmax, template = "govardovskii_a1"), 1.10)
+    expect_lt(band(lmax, template = "govardovskii_a2") / band(lmax, template = "govardovskii_a1"), 1.25)
   }
 
   # Stavenga (2010) reports the Govardovskii and SSH alpha bands to be close for
   # peaksens above 400 nm, and to diverge in the ultraviolet
-  dev <- function(lmax) {
-    a <- sensmodel(lmax, template = "govardovskii_a1", beta = FALSE, integrate = FALSE)
-    b <- sensmodel(lmax, template = "ssh_a1", beta = FALSE, integrate = FALSE)
+  dev <- function(lmax, x, y) {
+    a <- sensmodel(lmax, template = x, beta = FALSE, integrate = FALSE)
+    b <- sensmodel(lmax, template = y, beta = FALSE, integrate = FALSE)
     max(abs(a[[2]] - b[[2]]))
   }
-  expect_lt(dev(500), 0.05)
-  expect_lt(dev(600), 0.05)
-  expect_gt(dev(360), 0.10)
+  expect_lt(dev(500, "govardovskii_a1", "ssh_a1"), 0.05)
+  expect_lt(dev(600, "govardovskii_a1", "ssh_a1"), 0.05)
+  expect_gt(dev(360, "govardovskii_a1", "ssh_a1"), 0.10)
+
+  # The two A2 templates are independent fits to different data, so they are not
+  # expected to agree as closely as the A1 pair, but they should be in the same
+  # place across the range where both were fitted
+  expect_lt(dev(500, "govardovskii_a2", "ssh_a2"), 0.10)
+  expect_lt(dev(600, "govardovskii_a2", "ssh_a2"), 0.10)
 })
 
 test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigments", {
@@ -121,6 +131,13 @@ test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigment
   # Long-wavelength pigments, where the fixed beta band is far from the alpha
   # band, are unaffected
   expect_equal(realised(600, template = "ssh_a2"), 600)
+
+  # Govardovskii's A2 beta band scales with peaksens, so unlike ssh_a2 it stays
+  # within a couple of nm across the range it was fitted over. This is the reason
+  # govardovskii_a2 is the documented recommendation for porphyropsins.
+  for (lmax in c(440, 470, 500, 560, 620)) {
+    expect_lt(abs(realised(lmax, template = "govardovskii_a2") - lmax), 3)
+  }
 
   # None of this warns
   expect_silent(sensmodel(430, template = "ssh_a2"))

--- a/tests/testthat/test-sensmodel.R
+++ b/tests/testthat/test-sensmodel.R
@@ -111,14 +111,16 @@ test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigment
   expect_lt(realised(395, template = "ssh_a1"), 395 - 5)
 
   # The alpha band alone recovers peaksens exactly, and the default template is
-  # unaffected at the same peak sensitivities
-  expect_identical(realised(430, template = "ssh_a2", beta = FALSE), 430)
-  expect_identical(realised(395, template = "ssh_a1", beta = FALSE), 395)
-  expect_identical(realised(430, template = "govardovskii_a1"), 430)
+  # unaffected at the same peak sensitivities. expect_equal rather than
+  # expect_identical because wl is an integer sequence, and the type is beside
+  # the point here.
+  expect_equal(realised(430, template = "ssh_a2", beta = FALSE), 430)
+  expect_equal(realised(395, template = "ssh_a1", beta = FALSE), 395)
+  expect_equal(realised(430, template = "govardovskii_a1"), 430)
 
   # Long-wavelength pigments, where the fixed beta band is far from the alpha
   # band, are unaffected
-  expect_identical(realised(600, template = "ssh_a2"), 600)
+  expect_equal(realised(600, template = "ssh_a2"), 600)
 
   # None of this warns
   expect_silent(sensmodel(430, template = "ssh_a2"))

--- a/tests/testthat/test-sensmodel.R
+++ b/tests/testthat/test-sensmodel.R
@@ -109,11 +109,10 @@ test_that("sensmodel() templates", {
 test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigments", {
   # The SSH beta band sits at a fixed wavelength rather than scaling with
   # peaksens, so summing it with the alpha band moves the maximum of the result.
-  # This is a property of the published template, not an error, which is why
-  # beta = FALSE is the documented recommendation rather than a warning. The test
-  # exists so that anyone changing the beta band notices they have done so.
+  # Warnings are suppressed here because these assertions are about where the
+  # peak lands; the warning itself is checked separately below.
   realised <- function(...) {
-    s <- sensmodel(..., integrate = FALSE)
+    s <- suppressWarnings(sensmodel(..., integrate = FALSE))
     s$wl[which.max(s[[2]])]
   }
 
@@ -138,9 +137,17 @@ test_that("sensmodel() SSH beta band shifts the peak of short-wavelength pigment
     expect_lt(abs(realised(lmax, template = "govardovskii_a2") - lmax), 3)
   }
 
-  # None of this warns
-  expect_silent(sensmodel(430, template = "ssh_a2"))
-  expect_silent(sensmodel(395, template = "ssh_a1"))
+  # The shift is warned about, since a caveat in the documentation is easy to
+  # miss. Scoped to the SSH templates and to shifts beyond 5 nm, so it stays
+  # silent for the Govardovskii templates, for long-wavelength pigments where the
+  # fixed beta band is far from the alpha band, and when beta is switched off.
+  expect_warning(sensmodel(430, template = "ssh_a2"), "fixed peak wavelength")
+  expect_warning(sensmodel(395, template = "ssh_a1"), "fixed peak wavelength")
+
+  expect_silent(sensmodel(600, template = "ssh_a2"))
+  expect_silent(sensmodel(430, template = "ssh_a2", beta = FALSE))
+  expect_silent(sensmodel(430, template = "govardovskii_a1"))
+  expect_silent(sensmodel(470, template = "govardovskii_a2"))
 })
 
 test_that("sensmodel() errors", {


### PR DESCRIPTION
Adds a few additional templates - something on the todo for ages. Useful for both contemporary interest, sensitivity analyses/modelling ideas, and for recreating published results. I know sensmodel() is crowded already and this unfortunately adds another argument, but imo it's worthwhile on balance and there's nothing else out there that provides this kind of thing (even if it's a bit niche, but hey that's what we do).